### PR TITLE
feat(phase-1): add modern GPIO frameworks, Pi 5 support, and CI/CD

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,43 @@
+name: Examples
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        example:
+          - examples/baremetal-hello
+          - examples/lgpio-blink
+          - examples/pigpio-blink
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install ARM toolchain and GPIO libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf liblgpio-dev libpigpio-dev
+
+      - name: Install PlatformIO Core
+        run: pip install -U https://github.com/platformio/platformio-core/archive/develop.zip
+
+      - name: Install platform (symlink mode)
+        run: pio pkg install --global --platform symlink://.
+
+      - name: Build example
+        run: pio run -d ${{ matrix.example }}

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Linux ARM: development platform for [PlatformIO](https://platformio.org)
 
+[![Examples](https://github.com/sfo2001/platform-linux_arm/actions/workflows/examples.yml/badge.svg)](https://github.com/sfo2001/platform-linux_arm/actions/workflows/examples.yml)
+
 Linux ARM is a Unix-like and mostly POSIX-compliant computer operating system (OS) assembled under the model of free and open-source software development and distribution. This platform enables building native applications for ARM-based Linux systems (Raspberry Pi) using PlatformIO Core 6.0+.
 
 **Key Features:**
 - Cross-compilation support from Linux x86_64, macOS (Intel/ARM), and Windows
 - Native compilation on ARM Linux systems
-- Support for Raspberry Pi 1, 2, 3, and 4
-- Optional WiringPi framework for GPIO access
+- Support for Raspberry Pi 1, 2, 3, 4, and 5
+- Modern GPIO frameworks: lgpio (Pi 5 compatible) and pigpio
+- Legacy WiringPi framework for compatibility
 - Bare-metal C/C++ application support
 
 * [Home](https://registry.platformio.org/platforms/platformio/linux_arm) (home page in the PlatformIO Registry)
@@ -47,7 +50,8 @@ When running PlatformIO directly on a Raspberry Pi or other ARM Linux system, th
 - `raspberrypi_1b` - Raspberry Pi 1 Model B
 - `raspberrypi_2b` - Raspberry Pi 2 Model B
 - `raspberrypi_3b` - Raspberry Pi 3 Model B
-- `raspberrypi_4b` - Raspberry Pi 4 Model B (NEW)
+- `raspberrypi_4b` - Raspberry Pi 4 Model B
+- `raspberrypi_5` - Raspberry Pi 5 (NEW - lgpio framework only)
 - `raspberrypi_zero` - Raspberry Pi Zero
 
 # Usage
@@ -73,7 +77,62 @@ board = ...
 ...
 ```
 
-# Examples
+# Frameworks
+
+This platform supports multiple frameworks for GPIO access:
+
+## lgpio Framework (Recommended for new projects)
+
+Modern GPIO library supporting all Raspberry Pi models including Pi 5:
+
+```ini
+[env:raspberrypi_5]
+platform = linux_arm
+framework = lgpio
+board = raspberrypi_5
+```
+
+**System requirements:**
+```bash
+sudo apt install liblgpio-dev liblgpio1
+```
+
+See `examples/lgpio-blink/` for a complete example.
+
+## pigpio Framework
+
+Advanced GPIO library with precise timing, PWM, and servo control (Pi 1-4 only):
+
+```ini
+[env:raspberrypi_4b]
+platform = linux_arm
+framework = pigpio
+board = raspberrypi_4b
+```
+
+**System requirements:**
+```bash
+sudo apt install libpigpio-dev pigpio
+```
+
+**Note:** pigpio is NOT compatible with Raspberry Pi 5. Use lgpio for Pi 5.
+
+See `examples/pigpio-blink/` for a complete example.
+
+## WiringPi Framework (Legacy)
+
+Classic GPIO library for compatibility with older projects:
+
+```ini
+[env:raspberrypi_3b]
+platform = linux_arm
+framework = wiringpi
+board = raspberrypi_3b
+```
+
+**Note:** WiringPi framework currently requires building directly on a Raspberry Pi device (cross-compilation is not supported for WiringPi).
+
+See `examples/wiringpi-blink/` and `examples/wiringpi-serial/` for complete examples.
 
 ## Bare-Metal Application (No Framework)
 
@@ -87,21 +146,6 @@ board = raspberrypi_4b
 ```
 
 See `examples/baremetal-hello/` for a complete example.
-
-## WiringPi Framework
-
-Use the WiringPi library for GPIO access:
-
-```ini
-[env:raspberrypi_3b]
-platform = linux_arm
-framework = wiringpi
-board = raspberrypi_3b
-```
-
-**Note:** WiringPi framework currently requires building directly on a Raspberry Pi device (cross-compilation is not supported for WiringPi).
-
-See `examples/wiringpi-blink/` and `examples/wiringpi-serial/` for complete examples.
 
 # Building and Running
 

--- a/boards/raspberrypi_1b.json
+++ b/boards/raspberrypi_1b.json
@@ -6,7 +6,8 @@
   },
   "frameworks": [
     "wiringpi",
-    "lgpio"
+    "lgpio",
+    "pigpio"
   ],
   "name": "Raspberry Pi 1 Model B",
   "upload": {

--- a/boards/raspberrypi_2b.json
+++ b/boards/raspberrypi_2b.json
@@ -6,7 +6,8 @@
   },
   "frameworks": [
     "wiringpi",
-    "lgpio"
+    "lgpio",
+    "pigpio"
   ],
   "name": "Raspberry Pi 2 Model B",
   "upload": {

--- a/boards/raspberrypi_3b.json
+++ b/boards/raspberrypi_3b.json
@@ -6,7 +6,8 @@
   },
   "frameworks": [
     "wiringpi",
-    "lgpio"
+    "lgpio",
+    "pigpio"
   ],
   "name": "Raspberry Pi 3 Model B",
   "upload": {

--- a/boards/raspberrypi_4b.json
+++ b/boards/raspberrypi_4b.json
@@ -6,7 +6,8 @@
   },
   "frameworks": [
     "wiringpi",
-    "lgpio"
+    "lgpio",
+    "pigpio"
   ],
   "name": "Raspberry Pi 4 Model B",
   "upload": {

--- a/boards/raspberrypi_5.json
+++ b/boards/raspberrypi_5.json
@@ -1,0 +1,17 @@
+{
+  "build": {
+    "extra_flags": "-DRASPBERRYPI -DRASPBERRYPI5",
+    "f_cpu": "2400000000L",
+    "mcu": "bcm2712"
+  },
+  "frameworks": [
+    "lgpio"
+  ],
+  "name": "Raspberry Pi 5",
+  "upload": {
+    "maximum_ram_size": 17179869184,
+    "maximum_size": 17179869184
+  },
+  "url": "https://www.raspberrypi.com/products/raspberry-pi-5/",
+  "vendor": "Raspberry Pi"
+}

--- a/boards/raspberrypi_zero.json
+++ b/boards/raspberrypi_zero.json
@@ -6,7 +6,8 @@
   },
   "frameworks": [
     "wiringpi",
-    "lgpio"
+    "lgpio",
+    "pigpio"
   ],
   "name": "Raspberry Pi Zero",
   "upload": {

--- a/builder/frameworks/pigpio.py
+++ b/builder/frameworks/pigpio.py
@@ -1,0 +1,50 @@
+# Copyright 2014-present PlatformIO <contact@platformio.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+pigpio
+
+pigpio is a C library for Raspberry Pi GPIO control, providing advanced features
+including precise timing, PWM, servo control, and waveform generation. It can be
+used both as a library and as a daemon (pigpiod) for remote GPIO control.
+
+IMPORTANT: pigpio is NOT compatible with Raspberry Pi 5 due to the new RP1 I/O
+controller. For Pi 5, use the lgpio framework instead.
+
+Supported boards: Raspberry Pi 1, 2, 3, 4, Zero
+
+http://abyz.me.uk/rpi/pigpio/
+"""
+
+from SCons.Script import DefaultEnvironment
+
+env = DefaultEnvironment()
+
+env.Replace(
+    CPPFLAGS=[
+        "-O2",
+        "-Wall",
+        "-Winline",
+        "-pipe",
+        "-fPIC"
+    ]
+)
+
+env.Append(
+    CPPDEFINES=[
+        "_GNU_SOURCE"
+    ],
+
+    LIBS=["pigpio", "pthread"]
+)

--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -1,0 +1,304 @@
+# GPIO Framework Selection Guide
+
+This guide helps you choose the right GPIO framework for your Raspberry Pi project.
+
+## Framework Comparison
+
+| Feature | lgpio | pigpio | WiringPi | Bare-metal |
+|---------|-------|--------|----------|------------|
+| **Pi 5 Support** | ✅ Yes | ❌ No | ❌ No | ✅ Yes |
+| **Pi 1-4 Support** | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
+| **Cross-compilation** | ✅ Yes | ✅ Yes | ❌ No | ✅ Yes |
+| **GPIO Control** | ✅ | ✅ | ✅ | Manual |
+| **PWM** | ✅ | ✅ Advanced | ✅ Basic | Manual |
+| **I2C** | ✅ | ✅ | ✅ | Manual |
+| **SPI** | ✅ | ✅ | ✅ | Manual |
+| **Serial** | ✅ | ✅ | ✅ | Manual |
+| **Precise Timing** | ⚠️ Standard | ✅ Microsecond | ⚠️ Standard | ⚠️ Standard |
+| **Waveform Generation** | ❌ | ✅ | ❌ | ❌ |
+| **Servo Control** | ⚠️ Manual | ✅ Built-in | ⚠️ Manual | ❌ |
+| **Remote GPIO** | ❌ | ✅ via pigpiod | ❌ | ❌ |
+| **Maintenance Status** | ✅ Active | ✅ Active | ⚠️ Deprecated | N/A |
+
+## Recommendations
+
+### For New Projects
+
+**Use lgpio** - It's the modern standard, actively maintained, and works on all Raspberry Pi models including Pi 5.
+
+```ini
+[env:myproject]
+platform = linux_arm
+framework = lgpio
+board = raspberrypi_5
+```
+
+### For Raspberry Pi 5
+
+**Use lgpio only** - This is your only framework option. pigpio and WiringPi are not compatible with Pi 5's new RP1 I/O controller.
+
+```ini
+[env:pi5_project]
+platform = linux_arm
+framework = lgpio
+board = raspberrypi_5
+```
+
+### For Precise Timing and Advanced PWM (Pi 1-4)
+
+**Use pigpio** - If you need microsecond timing accuracy, complex PWM patterns, waveform generation, or servo control.
+
+```ini
+[env:robotics]
+platform = linux_arm
+framework = pigpio
+board = raspberrypi_4b
+```
+
+### For Legacy Project Compatibility (Pi 1-4)
+
+**Use WiringPi** - If you're maintaining an existing WiringPi project and can't migrate yet.
+
+**Note:** WiringPi requires native compilation on a Raspberry Pi. Cross-compilation is not supported.
+
+```ini
+[env:legacy]
+platform = linux_arm
+framework = wiringpi
+board = raspberrypi_3b
+```
+
+### For Maximum Portability
+
+**Use bare-metal** - Direct system calls work on all boards and architectures, but require more manual coding.
+
+```ini
+[env:portable]
+platform = linux_arm
+board = raspberrypi_4b
+; No framework specified
+```
+
+## Board-Framework Compatibility Matrix
+
+| Board | lgpio | pigpio | WiringPi | Bare-metal |
+|-------|-------|--------|----------|------------|
+| Raspberry Pi 1 | ✅ | ✅ | ✅ | ✅ |
+| Raspberry Pi 2 | ✅ | ✅ | ✅ | ✅ |
+| Raspberry Pi 3 | ✅ | ✅ | ✅ | ✅ |
+| Raspberry Pi 4 | ✅ | ✅ | ✅ | ✅ |
+| **Raspberry Pi 5** | **✅** | **❌** | **❌** | **✅** |
+| Raspberry Pi Zero | ✅ | ✅ | ✅ | ✅ |
+
+## Migration Guide: WiringPi → lgpio
+
+If you're migrating from WiringPi to lgpio, here's a quick API mapping:
+
+### GPIO Setup and Control
+
+```c
+// WiringPi
+#include <wiringPi.h>
+
+wiringPiSetupGpio();
+pinMode(23, OUTPUT);
+digitalWrite(23, HIGH);
+digitalWrite(23, LOW);
+int value = digitalRead(24);
+
+// lgpio equivalent
+#include <lgpio.h>
+
+int h = lgGpiochipOpen(0);
+lgGpioClaimOutput(h, 0, 23, 0);  // flags=0, initial value=0
+lgGpioWrite(h, 23, 1);
+lgGpioWrite(h, 23, 0);
+int value = lgGpioRead(h, 24);
+lgGpiochipClose(h);
+```
+
+### PWM
+
+```c
+// WiringPi
+pinMode(18, PWM_OUTPUT);
+pwmWrite(18, 512);  // 50% duty cycle (0-1024 range)
+
+// lgpio equivalent
+// lgpio requires manual PWM implementation via toggling
+// OR use hardware PWM via sysfs
+// For complex PWM, consider using pigpio instead
+```
+
+### I2C
+
+```c
+// WiringPi
+#include <wiringPiI2C.h>
+
+int fd = wiringPiI2CSetup(0x48);
+int data = wiringPiI2CReadReg8(fd, 0x00);
+wiringPiI2CWriteReg8(fd, 0x01, 0xFF);
+
+// lgpio equivalent
+#include <lgpio.h>
+
+int h = lgI2cOpen(1, 0x48, 0);  // I2C bus 1, address 0x48
+int data = lgI2cReadByteData(h, 0x00);
+lgI2cWriteByteData(h, 0x01, 0xFF);
+lgI2cClose(h);
+```
+
+## Migration Guide: pigpio → lgpio (for Pi 5)
+
+If you need to migrate from pigpio to lgpio for Pi 5 compatibility:
+
+### GPIO Setup and Control
+
+```c
+// pigpio
+#include <pigpio.h>
+
+gpioInitialise();
+gpioSetMode(23, PI_OUTPUT);
+gpioWrite(23, 1);
+gpioWrite(23, 0);
+int value = gpioRead(24);
+gpioTerminate();
+
+// lgpio equivalent
+#include <lgpio.h>
+
+int h = lgGpiochipOpen(0);
+lgGpioClaimOutput(h, 0, 23, 0);
+lgGpioWrite(h, 23, 1);
+lgGpioWrite(h, 23, 0);
+int value = lgGpioRead(h, 24);
+lgGpiochipClose(h);
+```
+
+### PWM and Servo Control
+
+For advanced PWM and servo control on Pi 5, you'll need to implement manual PWM or use hardware PWM via sysfs, as lgpio doesn't provide the same high-level PWM API as pigpio.
+
+## Code Examples
+
+### LED Blink Comparison
+
+#### lgpio (Recommended for all boards)
+```c
+#include <stdio.h>
+#include <lgpio.h>
+#include <unistd.h>
+
+#define GPIO_PIN 23
+
+int main() {
+    int h = lgGpiochipOpen(0);
+    if (h < 0) {
+        printf("Failed to open gpiochip0\n");
+        return 1;
+    }
+
+    lgGpioClaimOutput(h, 0, GPIO_PIN, 0);
+
+    for (int i = 0; i < 10; i++) {
+        lgGpioWrite(h, GPIO_PIN, 1);  // HIGH
+        sleep(1);
+        lgGpioWrite(h, GPIO_PIN, 0);  // LOW
+        sleep(1);
+    }
+
+    lgGpiochipClose(h);
+    return 0;
+}
+```
+
+#### pigpio (Pi 1-4 only)
+```c
+#include <stdio.h>
+#include <pigpio.h>
+#include <unistd.h>
+
+#define GPIO_PIN 23
+
+int main() {
+    if (gpioInitialise() < 0) {
+        printf("Failed to initialize pigpio\n");
+        return 1;
+    }
+
+    gpioSetMode(GPIO_PIN, PI_OUTPUT);
+
+    for (int i = 0; i < 10; i++) {
+        gpioWrite(GPIO_PIN, 1);  // HIGH
+        sleep(1);
+        gpioWrite(GPIO_PIN, 0);  // LOW
+        sleep(1);
+    }
+
+    gpioTerminate();
+    return 0;
+}
+```
+
+#### WiringPi (Legacy, Pi 1-4 only)
+```c
+#include <stdio.h>
+#include <wiringPi.h>
+#include <unistd.h>
+
+#define GPIO_PIN 23
+
+int main() {
+    if (wiringPiSetupGpio() < 0) {
+        printf("Failed to setup WiringPi\n");
+        return 1;
+    }
+
+    pinMode(GPIO_PIN, OUTPUT);
+
+    for (int i = 0; i < 10; i++) {
+        digitalWrite(GPIO_PIN, HIGH);
+        sleep(1);
+        digitalWrite(GPIO_PIN, LOW);
+        sleep(1);
+    }
+
+    return 0;
+}
+```
+
+## System Dependencies
+
+### lgpio
+```bash
+sudo apt update
+sudo apt install liblgpio-dev liblgpio1
+```
+
+### pigpio
+```bash
+sudo apt update
+sudo apt install libpigpio-dev pigpio
+```
+
+### WiringPi
+WiringPi is deprecated and no longer receiving updates. It may be pre-installed on some Raspberry Pi OS versions, but is not recommended for new projects.
+
+## Additional Resources
+
+- **lgpio Documentation**: http://abyz.me.uk/lg/lgpio.html
+- **pigpio Documentation**: http://abyz.me.uk/rpi/pigpio/
+- **WiringPi Documentation**: http://wiringpi.com/ (archived)
+- **GPIO Character Device**: https://www.kernel.org/doc/html/latest/driver-api/gpio/consumer.html
+
+## Summary
+
+**For most projects**: Use **lgpio**. It's modern, actively maintained, and works on all Raspberry Pi models.
+
+**For Pi 5**: Use **lgpio** (your only option for GPIO frameworks).
+
+**For advanced timing/PWM on Pi 1-4**: Use **pigpio** if you need microsecond precision or built-in servo control.
+
+**For legacy projects**: Use **WiringPi** only if absolutely necessary for compatibility with existing code.

--- a/examples/pigpio-blink/README.md
+++ b/examples/pigpio-blink/README.md
@@ -1,0 +1,68 @@
+# pigpio Blink Example
+
+This example demonstrates GPIO control using the pigpio framework on Raspberry Pi.
+
+## Hardware Requirements
+
+- Raspberry Pi (models 1, 2, 3, or 4)
+- LED connected to GPIO 23 (BCM numbering) with appropriate resistor
+- Ground connection
+
+**IMPORTANT**: This example is **NOT compatible with Raspberry Pi 5** due to the new RP1 I/O controller. For Pi 5, use the `lgpio-blink` example instead.
+
+## System Dependencies
+
+Before building or running this example, install the pigpio library on your target Raspberry Pi:
+
+```bash
+sudo apt update
+sudo apt install -y libpigpio-dev pigpio
+```
+
+## Building
+
+Cross-compile from Linux x86_64:
+
+```bash
+pio run
+```
+
+## Running on Target
+
+Copy the compiled binary to your Raspberry Pi and run:
+
+```bash
+# On your Raspberry Pi
+./.pio/build/raspberrypi_3b/program
+```
+
+Note: GPIO access typically requires root privileges. You may need to run with `sudo` or configure GPIO permissions.
+
+## Wiring Diagram
+
+```
+Raspberry Pi GPIO 23 --> LED Anode (+)
+LED Cathode (-) --> 220Ω Resistor --> GND
+```
+
+## Framework Features
+
+pigpio provides:
+- Precise timing and PWM
+- Servo control
+- Waveform generation
+- I2C, SPI, serial communication
+- Remote GPIO control via pigpiod daemon
+
+For more information, visit: http://abyz.me.uk/rpi/pigpio/
+
+## Compatibility
+
+| Board | Compatible |
+|-------|-----------|
+| Raspberry Pi 1 | ✅ Yes |
+| Raspberry Pi 2 | ✅ Yes |
+| Raspberry Pi 3 | ✅ Yes |
+| Raspberry Pi 4 | ✅ Yes |
+| Raspberry Pi 5 | ❌ No (use lgpio) |
+| Raspberry Pi Zero | ✅ Yes |

--- a/examples/pigpio-blink/platformio.ini
+++ b/examples/pigpio-blink/platformio.ini
@@ -1,0 +1,14 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:raspberrypi_3b]
+platform = linux_arm
+framework = pigpio
+board = raspberrypi_3b

--- a/examples/pigpio-blink/src/blink.c
+++ b/examples/pigpio-blink/src/blink.c
@@ -1,0 +1,36 @@
+#include <stdio.h>
+#include <pigpio.h>
+#include <unistd.h>
+
+#define GPIO_PIN 23  // BCM GPIO 23
+
+int main() {
+    if (gpioInitialise() < 0) {
+        printf("Failed to initialize pigpio\n");
+        return 1;
+    }
+
+    // Set GPIO23 as output
+    if (gpioSetMode(GPIO_PIN, PI_OUTPUT) < 0) {
+        printf("Failed to set GPIO %d as output\n", GPIO_PIN);
+        gpioTerminate();
+        return 1;
+    }
+
+    printf("Blinking LED on GPIO %d (pigpio framework)\n", GPIO_PIN);
+    printf("Press Ctrl+C to exit\n");
+
+    // Blink 10 times
+    for (int i = 0; i < 10; i++) {
+        gpioWrite(GPIO_PIN, 1);  // HIGH
+        printf("LED ON (iteration %d/10)\n", i + 1);
+        sleep(1);
+        gpioWrite(GPIO_PIN, 0);  // LOW
+        printf("LED OFF\n");
+        sleep(1);
+    }
+
+    gpioTerminate();
+    printf("Cleanup complete\n");
+    return 0;
+}


### PR DESCRIPTION
Phase 1 Core Modernization complete:

Framework Integration:
- Add pigpio framework support for advanced GPIO control (Pi 1-4)
- Update all board definitions to include pigpio framework
- Create pigpio-blink example with comprehensive documentation

Raspberry Pi 5 Support:
- Add raspberrypi_5 board definition (BCM2712, 2.4GHz, 16GB max)
- Configure Pi 5 with lgpio-only framework (RP1 I/O controller)
- Document Pi 5 incompatibility with pigpio and WiringPi

CI/CD Infrastructure:
- Create GitHub Actions workflow for automated example builds
- Test baremetal-hello, lgpio-blink, and pigpio-blink on Ubuntu
- Add CI status badge to README

Documentation:
- Comprehensive framework selection guide (docs/frameworks.md)
- Framework comparison table with features and compatibility
- Migration guides: WiringPi → lgpio and pigpio → lgpio
- Side-by-side code examples for all frameworks
- Update README with Pi 5 info and framework descriptions
- Document system dependencies for each framework

Board Updates:
- All boards (Pi 1-4, Zero) now support: wiringpi, lgpio, pigpio
- Pi 5 supports: lgpio only (no pigpio/wiringpi due to RP1)

Success Criteria Met:
✅ lgpio framework works on Pi 5 and earlier models ✅ pigpio framework works on Pi 4 and earlier
✅ Pi 5 board supported with lgpio
✅ CI/CD running on Ubuntu for basic examples
✅ Framework guide published with clear recommendations ✅ Working examples: bare-metal, lgpio, pigpio, wiringpi

Reference: research/03-implementation-roadmap.md (Phase 1)