### PR TITLE
fix: lgpio framework library detection for cross-compiled builds

### DIFF
--- a/builder/frameworks/lgpio.py
+++ b/builder/frameworks/lgpio.py
@@ -89,16 +89,14 @@ for base_path in lgpio_search_paths:
                 print("Found lgpio at: %s (multiarch armhf)" % base_path)
                 break
 
-        # Check standard lib path (native package or architecture-neutral paths only)
-        # Skip this fallback for architecture-specific base paths to avoid wrong-arch libraries
-        is_arch_specific_path = ("arm-linux-gnueabihf" in base_path or "aarch64-linux-gnu" in base_path)
-
-        if not is_arch_specific_path:
-            if isfile(join(lib_path, "liblgpio.so")) or isfile(join(lib_path, "liblgpio.so.1")):
-                lgpio_include = inc_path
-                lgpio_lib = lib_path
-                print("Found lgpio at: %s" % base_path)
-                break
+        # Check standard lib path as fallback
+        # Architecture-specific base paths (e.g., ~/.local/arm-linux-gnueabihf/)
+        # provide architecture isolation, so it's safe to check lib/ subdirectory
+        if isfile(join(lib_path, "liblgpio.so")) or isfile(join(lib_path, "liblgpio.so.1")):
+            lgpio_include = inc_path
+            lgpio_lib = lib_path
+            print("Found lgpio at: %s" % base_path)
+            break
 
 if not lgpio_include or not lgpio_lib:
     arch_name = "aarch64 (64-bit)" if is_aarch64 else "armhf (32-bit)"


### PR DESCRIPTION
The lgpio framework builder was failing to detect cross-compiled lgpio libraries installed in architecture-specific directories like:
  ~/.local/arm-linux-gnueabihf/lib/
  ~/.local/aarch64-linux-gnu/lib/

Root cause: The search logic incorrectly skipped checking the standard lib/ subdirectory for architecture-specific base paths, assuming they would always use multiarch subdirectories (lib/arm-linux-gnueabihf/).

However, when building with setup-lgpio-cross.sh script, libraries are installed directly to lib/, not lib/<triplet>/.

Fix: Remove the overly restrictive check that prevented searching the standard lib/ path for arch-specific base directories. The base path itself provides architecture isolation, making it safe to check lib/.

This fixes CI/CD build failures where lgpio was successfully compiled but not found during PlatformIO builds.

Resolves: Examples CI workflow failures for lgpio-blink