### PR TITLE
fix: prioritize correct architecture in lgpio library search

### DIFF
--- a/builder/frameworks/lgpio.py
+++ b/builder/frameworks/lgpio.py
@@ -52,16 +52,33 @@ is_aarch64 = (target_arch == "aarch64")
 
 # Detect lgpio installation paths
 # Priority: 1) User local build, 2) System-wide build, 3) System package
+# For correct cross-compilation, prioritize architecture-specific paths first
 home = expanduser("~")
-lgpio_search_paths = [
-    join(home, ".local", "arm-linux-gnueabihf"),  # User-built 32-bit (recommended)
-    join(home, ".local", "aarch64-linux-gnu"),    # User-built 64-bit
-    "/usr/local/arm-linux-gnueabihf",             # System-wide build 32-bit
-    "/usr/local/aarch64-linux-gnu",               # System-wide build 64-bit
-    "/usr/arm-linux-gnueabihf",                   # Multiarch package location 32-bit
-    "/usr/aarch64-linux-gnu",                     # Multiarch package location 64-bit
-    "/usr",                                        # Native package fallback
-]
+
+# Build architecture-specific search path list
+# Put the target architecture's paths FIRST to avoid finding wrong architecture
+if is_aarch64:
+    # 64-bit build: prioritize aarch64 paths
+    lgpio_search_paths = [
+        join(home, ".local", "aarch64-linux-gnu"),    # User-built 64-bit (recommended)
+        "/usr/local/aarch64-linux-gnu",               # System-wide build 64-bit
+        "/usr/aarch64-linux-gnu",                     # Multiarch package location 64-bit
+        join(home, ".local", "arm-linux-gnueabihf"),  # User-built 32-bit (fallback)
+        "/usr/local/arm-linux-gnueabihf",             # System-wide build 32-bit
+        "/usr/arm-linux-gnueabihf",                   # Multiarch package location 32-bit
+        "/usr",                                        # Native package fallback
+    ]
+else:
+    # 32-bit build: prioritize armhf paths
+    lgpio_search_paths = [
+        join(home, ".local", "arm-linux-gnueabihf"),  # User-built 32-bit (recommended)
+        "/usr/local/arm-linux-gnueabihf",             # System-wide build 32-bit
+        "/usr/arm-linux-gnueabihf",                   # Multiarch package location 32-bit
+        join(home, ".local", "aarch64-linux-gnu"),    # User-built 64-bit (fallback)
+        "/usr/local/aarch64-linux-gnu",               # System-wide build 64-bit
+        "/usr/aarch64-linux-gnu",                     # Multiarch package location 64-bit
+        "/usr",                                        # Native package fallback
+    ]
 
 lgpio_include = None
 lgpio_lib = None


### PR DESCRIPTION
The lgpio framework builder was searching for libraries in a fixed order, causing 64-bit builds (raspberrypi_5_64bit) to incorrectly find and link against 32-bit libraries.

Root cause:
- Search paths had arm-linux-gnueabihf (32-bit) before aarch64-linux-gnu (64-bit)
- For aarch64 builds, it would find lgpio.h in 32-bit path, check for multiarch aarch64 subdirectory (doesn't exist), then fall back to the 32-bit lib/ directory
- Linker would reject incompatible 32-bit library and fail with: "ld: cannot find -llgpio: No such file or directory"

Fix:
- Reorder search paths based on target architecture
- aarch64 builds now check aarch64-linux-gnu paths FIRST
- armhf builds check arm-linux-gnueabihf paths FIRST
- This ensures the correct architecture's library is found and linked

Fixes raspberrypi_5_64bit build failure in CI.