### PR TITLE
feat(examples): add baremetal-uart serial communication example

### DIFF
--- a/examples/baremetal-uart/.gitignore
+++ b/examples/baremetal-uart/.gitignore
@@ -1,0 +1,2 @@
+.pio
+.vscode

--- a/examples/baremetal-uart/README.md
+++ b/examples/baremetal-uart/README.md
@@ -1,0 +1,540 @@
+# Bare-Metal UART Serial Communication Example
+
+A comprehensive example demonstrating asynchronous serial communication on Raspberry Pi using the standard Linux `termios` API. No GPIO library or framework required - pure POSIX serial port interface.
+
+## Overview
+
+This example showcases professional serial port programming techniques commonly needed for:
+- **GPS modules** (NMEA data parsing)
+- **Bluetooth serial** (HC-05, HC-06 modules)
+- **GSM/LTE modems** (AT command interface)
+- **Serial sensors** (temperature, pressure, etc.)
+- **USB-to-Serial adapters**
+- **Arduino/ESP32 communication**
+- **Industrial serial protocols** (Modbus RTU, etc.)
+
+### Key Features
+
+✅ **Proper termios configuration** following POSIX best practices
+✅ **Bidirectional communication** with echo test and interactive modes
+✅ **Non-blocking I/O** with timeout handling
+✅ **Comprehensive error handling** with helpful diagnostics
+✅ **Multiple operation modes** (echo test, interactive)
+✅ **Cross-compilation support** (build on x86_64, run on ARM)
+✅ **No framework dependency** - standard Linux APIs only
+
+### Learning Outcomes
+
+- Understanding Linux serial port device model (`/dev/tty*`)
+- Configuring `termios` structure (baud rate, parity, data bits, stop bits)
+- Non-blocking I/O with `select()` and timeouts
+- Proper error handling for serial communication
+- Data parsing and protocol implementation patterns
+
+## Hardware Connections
+
+### Option 1: Hardware UART on GPIO (Most Common)
+
+The Raspberry Pi's hardware UART is available on GPIO pins 14 and 15:
+
+```
+Raspberry Pi                  Serial Device
+┌─────────────┐              ┌──────────────┐
+│             │              │              │
+│  GPIO 14 TX │─────────────>│ RX           │
+│  (Pin 8)    │              │              │
+│             │              │              │
+│  GPIO 15 RX │<─────────────│ TX           │
+│  (Pin 10)   │              │              │
+│             │              │              │
+│  GND        │──────────────│ GND          │
+│  (Pin 6)    │              │              │
+└─────────────┘              └──────────────┘
+```
+
+**Pin mapping (40-pin header):**
+- **Pin 8** (GPIO 14) = TX (Transmit)
+- **Pin 10** (GPIO 15) = RX (Receive)
+- **Pin 6** (or any GND) = Ground
+
+**Voltage warning:** Raspberry Pi GPIO is **3.3V logic**. If connecting to 5V devices (like Arduino), use a logic level converter!
+
+### Option 2: USB-to-Serial Adapter
+
+Simply plug in a USB-to-Serial adapter (FTDI, CH340, CP2102, etc.):
+- Device will appear as `/dev/ttyUSB0` (or `/dev/ttyACM0` for some devices)
+- No GPIO wiring needed
+- Automatically detected by Linux kernel
+
+### Option 3: Loopback Test (No External Device)
+
+For testing without external hardware, connect TX to RX:
+- Connect GPIO 14 (Pin 8) to GPIO 15 (Pin 10)
+- Any data sent will be immediately received (echo)
+
+## Raspberry Pi UART Configuration
+
+### Step 1: Enable UART Hardware
+
+The UART may be disabled by default or used for Bluetooth. Enable it with:
+
+```bash
+sudo raspi-config
+```
+
+Navigate to: **Interface Options** → **Serial Port**
+- "Login shell accessible over serial?" → **No**
+- "Serial port hardware enabled?" → **Yes**
+
+Or manually edit `/boot/config.txt`:
+
+```bash
+sudo nano /boot/config.txt
+```
+
+Add or uncomment these lines:
+
+```ini
+# Enable UART
+enable_uart=1
+
+# For Pi 3/4/5: Disable Bluetooth to free up hardware UART (optional)
+# dtoverlay=disable-bt
+```
+
+Reboot after changes:
+
+```bash
+sudo reboot
+```
+
+### Step 2: Verify UART Devices
+
+Check available serial devices:
+
+```bash
+ls -l /dev/serial* /dev/tty{AMA,S,USB,ACM}*
+```
+
+Common devices:
+- `/dev/serial0` → Primary UART (symlink, **recommended**)
+- `/dev/ttyAMA0` → Hardware UART (Pi 1, 2, Zero)
+- `/dev/ttyS0` → Mini UART or Bluetooth (Pi 3, 4, 5)
+- `/dev/ttyUSB0` → USB-to-Serial adapter
+- `/dev/ttyACM0` → USB CDC ACM device
+
+**Best practice:** Use `/dev/serial0` as it always points to the primary UART regardless of Pi model.
+
+### Step 3: Fix Permissions (if needed)
+
+If you get "Permission denied" errors:
+
+```bash
+# Add your user to the dialout group
+sudo usermod -a -G dialout $USER
+
+# Log out and back in for changes to take effect
+```
+
+Or run with sudo:
+
+```bash
+sudo .pio/build/raspberrypi_3b/program
+```
+
+## Building
+
+### Prerequisites
+
+- PlatformIO Core 6.0+
+- ARM cross-compilation toolchain (automatically installed by PlatformIO)
+
+### Build for Specific Board
+
+```bash
+# Build for Raspberry Pi 3
+pio run -e raspberrypi_3b
+
+# Build for Raspberry Pi 4
+pio run -e raspberrypi_4b
+
+# Build for Raspberry Pi 5
+pio run -e raspberrypi_5
+
+# Build for Raspberry Pi Zero 2W
+pio run -e raspberrypi_zero2w
+
+# Clean build artifacts
+pio run --target clean
+```
+
+### Cross-Compilation
+
+This example can be cross-compiled from:
+- **Linux x86_64** (Ubuntu, Debian, etc.)
+- **macOS** (Intel or Apple Silicon)
+- **Windows x86_64** (WSL or native)
+
+PlatformIO will automatically download and configure the ARM toolchain.
+
+## Running
+
+After building, transfer the executable to your Raspberry Pi and run it:
+
+```bash
+# Transfer (from your dev machine)
+scp .pio/build/raspberrypi_3b/program pi@raspberrypi.local:~/uart-test
+
+# Run on Raspberry Pi
+ssh pi@raspberrypi.local
+./uart-test
+```
+
+Or if compiling directly on the Pi:
+
+```bash
+.pio/build/raspberrypi_3b/program
+```
+
+## Usage
+
+### Mode 1: Echo Test (Default)
+
+Sends predefined test messages and waits for echo responses. Ideal for loopback testing or devices that echo data back.
+
+```bash
+# Using default device (/dev/serial0)
+./program
+
+# Using specific device
+./program /dev/ttyUSB0
+```
+
+**Expected output:**
+```
+╔════════════════════════════════════════════════════╗
+║  Bare-Metal UART Serial Communication Example     ║
+║  Platform: Linux ARM (Raspberry Pi)               ║
+║  API: POSIX termios (no framework required)        ║
+╚════════════════════════════════════════════════════╝
+
+Configuration:
+  Device: /dev/serial0
+  Baud rate: 9600
+  Mode: Echo Test
+
+Opening serial port...
+✓ Serial port opened successfully
+Configuring serial parameters...
+✓ Serial port configured
+
+╔════════════════════════════════════════════════════╗
+║  Echo Test Mode                                    ║
+╚════════════════════════════════════════════════════╝
+
+TX: Hello from Raspberry Pi!
+RX: Waiting for response -> Hello from Raspberry Pi! ✓ Match
+
+TX: Testing UART communication
+RX: Waiting for response -> Testing UART communication ✓ Match
+
+✓ Echo test completed
+```
+
+### Mode 2: Interactive Mode
+
+Interactive bidirectional communication. Type messages to send, received data displayed automatically.
+
+```bash
+# Interactive mode with default device
+./program --interactive
+
+# Interactive mode with specific device
+./program --interactive /dev/ttyAMA0
+```
+
+**Example session:**
+```
+╔════════════════════════════════════════════════════╗
+║  Interactive Mode                                  ║
+╚════════════════════════════════════════════════════╝
+
+Type messages to send. Press Ctrl+C to exit.
+Received data will be displayed automatically.
+
+>> TX: AT
+<< RX: OK
+
+>> TX: Hello Arduino!
+<< RX: Received: Hello Arduino!
+```
+
+### Command-Line Options
+
+```bash
+# Show help
+./program --help
+
+# Echo test (default)
+./program [device]
+
+# Interactive mode
+./program --interactive [device]
+```
+
+## Testing Without Hardware
+
+### Software Loopback Test
+
+1. **Physical loopback**: Connect GPIO 14 to GPIO 15
+2. **Run echo test**:
+   ```bash
+   ./program /dev/serial0
+   ```
+3. All sent messages should be received back immediately
+
+### Using Virtual Serial Ports (socat)
+
+For testing without hardware or GPIO connections:
+
+```bash
+# Install socat
+sudo apt install socat
+
+# Create virtual serial port pair
+socat -d -d pty,raw,echo=0 pty,raw,echo=0
+# Note the devices created, e.g., /dev/pts/2 and /dev/pts/3
+
+# In terminal 1: Run program
+./program /dev/pts/2
+
+# In terminal 2: Communicate with it
+cat /dev/pts/3          # Receive
+echo "Hello" > /dev/pts/3  # Send
+```
+
+## Code Structure
+
+### Key Functions
+
+| Function | Purpose |
+|----------|---------|
+| `configure_serial_port()` | Sets up termios structure with proper POSIX flags |
+| `serial_write()` | Sends data and ensures transmission completes |
+| `serial_read_timeout()` | Reads data with timeout using `select()` |
+| `run_echo_test()` | Automated test sequence for validation |
+| `run_interactive_mode()` | User-interactive bidirectional communication |
+
+### termios Configuration Details
+
+The example demonstrates **proper POSIX termios configuration**:
+
+```c
+// Input flags: raw input, no processing
+c_iflag &= ~(IGNBRK | BRKINT | ICRNL | INLCR | PARMRK | INPCK | ISTRIP | IXON);
+
+// Output flags: raw output, no processing
+c_oflag &= ~(OCRNL | ONLCR | ONLRET | ONOCR | OFILL | OPOST);
+
+// Line flags: no canonical mode, no echo
+c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN | ISIG);
+
+// Control flags: 8N1 (8 data bits, no parity, 1 stop bit)
+c_cflag &= ~(CSIZE | PARENB | CSTOPB);
+c_cflag |= CS8 | CREAD | CLOCAL;
+
+// Timeouts: non-blocking with timeout
+c_cc[VMIN] = 0;   // Return immediately
+c_cc[VTIME] = 5;  // 0.5 second timeout
+```
+
+This is the **recommended approach** instead of zeroing the entire structure, as it preserves system-specific fields.
+
+## Common Use Cases
+
+### 1. GPS Module (NMEA Data)
+
+Connect GPS module TX to Pi RX:
+
+```bash
+./program --interactive /dev/serial0
+```
+
+You'll see NMEA sentences like:
+```
+<< RX: $GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47
+<< RX: $GPGLL,4916.45,N,12311.12,W,225444,A,*1D
+```
+
+### 2. Bluetooth Serial Module (HC-05)
+
+1. Wire: HC-05 TX → Pi RX, HC-05 RX → Pi TX (via level shifter!)
+2. Default baud: 9600 (HC-05 default)
+3. Run interactive mode:
+   ```bash
+   ./program --interactive /dev/serial0
+   ```
+4. Send AT commands:
+   ```
+   >> TX: AT
+   << RX: OK
+   ```
+
+### 3. Arduino Communication
+
+**Arduino sketch:**
+```cpp
+void setup() {
+  Serial.begin(9600);
+}
+
+void loop() {
+  if (Serial.available()) {
+    String data = Serial.readString();
+    Serial.print("Arduino received: ");
+    Serial.println(data);
+  }
+}
+```
+
+**Raspberry Pi:**
+```bash
+./program --interactive /dev/serial0
+>> TX: Hello Arduino!
+<< RX: Arduino received: Hello Arduino!
+```
+
+### 4. USB-to-Serial Adapter
+
+Plug in adapter, find device name:
+
+```bash
+dmesg | tail
+# Look for: "FTDI USB Serial Device converter now attached to ttyUSB0"
+
+./program /dev/ttyUSB0
+```
+
+## Troubleshooting
+
+### Issue: "Permission denied"
+
+**Solution:**
+```bash
+sudo usermod -a -G dialout $USER
+# Log out and back in
+```
+
+Or run with sudo:
+```bash
+sudo ./program
+```
+
+### Issue: "No such file or directory" (`/dev/serial0`)
+
+**Solution:**
+1. Check if UART is enabled:
+   ```bash
+   ls -l /dev/serial* /dev/tty{AMA,S}*
+   ```
+2. Enable UART in `raspi-config`
+3. Reboot
+
+### Issue: "Input/output error" or garbage data
+
+**Possible causes:**
+- Wrong baud rate (both devices must match)
+- Incorrect wiring (TX/RX swapped)
+- Voltage mismatch (use level shifter for 5V devices)
+- UART disabled in config
+
+**Solutions:**
+- Verify connections (TX → RX, RX → TX)
+- Check baud rate on both devices
+- Test with loopback (TX to RX on same device)
+
+### Issue: Timeout, no data received
+
+**Solutions:**
+- Verify other device is transmitting
+- Check wiring (especially TX/RX swap)
+- Test with loopback
+- Check device exists: `ls -l /dev/serial0`
+
+### Issue: Works with sudo but not without
+
+**Solution:**
+```bash
+# Check current permissions
+ls -l /dev/serial0
+
+# Add user to dialout group
+sudo usermod -a -G dialout $USER
+
+# Verify group membership after re-login
+groups
+```
+
+## Comparison with WiringPi Serial Example
+
+| Feature | Bare-Metal (termios) | WiringPi |
+|---------|---------------------|----------|
+| **API** | POSIX termios | WiringPi serialOpen/serialGetchar |
+| **Framework** | None (bare-metal) | WiringPi required |
+| **Portability** | Any Linux system | Raspberry Pi only |
+| **Learning value** | High (standard Linux API) | Lower (abstraction layer) |
+| **Cross-compile** | Yes | Limited (WiringPi dependency) |
+| **Configuration** | Full control (baud, parity, etc.) | Limited options |
+| **Dependencies** | None (libc only) | WiringPi library |
+| **Use cases** | Production, embedded Linux | Quick prototyping |
+
+**When to use bare-metal termios:**
+- Production applications
+- Learning Linux serial programming
+- Cross-platform Linux projects (not Pi-specific)
+- Full control over serial parameters
+- No external dependencies desired
+
+**When to use WiringPi:**
+- Quick prototypes
+- Already using WiringPi for GPIO
+- Simple serial needs
+
+## Further Reading
+
+### Official Documentation
+- [Linux Serial HOWTO](https://tldp.org/HOWTO/Serial-HOWTO.html)
+- [POSIX termios reference](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/termios.h.html)
+- [Raspberry Pi UART documentation](https://www.raspberrypi.com/documentation/computers/configuration.html#configuring-uarts)
+
+### Serial Protocols
+- NMEA 0183 (GPS): [NMEA Protocol Specification](https://www.nmea.org/)
+- Modbus RTU: [Modbus Protocol Guide](https://modbus.org/)
+- AT Commands: [AT Command Set](https://en.wikipedia.org/wiki/Hayes_command_set)
+
+### Raspberry Pi Resources
+- [Raspberry Pi Pinout](https://pinout.xyz/)
+- [UART Configuration Guide](https://www.raspberrypi.com/documentation/computers/configuration.html#configuring-uarts)
+
+## License
+
+This example is provided as educational material for the PlatformIO Linux ARM platform. Feel free to use and modify for your projects.
+
+## Related Examples
+
+- **baremetal-hello** - Simple bare-metal "Hello World"
+- **wiringpi-serial** - Serial communication using WiringPi framework (simpler but less flexible)
+- **lgpio-blink** - GPIO control with modern lgpio library
+- **pigpio-blink** - GPIO control with pigpio library
+
+## Contributing
+
+Found a bug or have an improvement? Contributions welcome!
+
+1. Test on your Raspberry Pi
+2. Document hardware setup and results
+3. Submit pull request with clear description
+
+---
+
+**Built with PlatformIO** | **Platform: Linux ARM** | **Framework: None (bare-metal)**

--- a/examples/baremetal-uart/platformio.ini
+++ b/examples/baremetal-uart/platformio.ini
@@ -1,0 +1,43 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter, extra scripting
+;   Upload options: custom port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:raspberrypi_1b]
+platform = linux_arm
+board = raspberrypi_1b
+; No framework specified - bare-metal C application
+
+[env:raspberrypi_2b]
+platform = linux_arm
+board = raspberrypi_2b
+; No framework specified - bare-metal C application
+
+[env:raspberrypi_3b]
+platform = linux_arm
+board = raspberrypi_3b
+; No framework specified - bare-metal C application
+
+[env:raspberrypi_4b]
+platform = linux_arm
+board = raspberrypi_4b
+; No framework specified - bare-metal C application
+
+[env:raspberrypi_5]
+platform = linux_arm
+board = raspberrypi_5
+; No framework specified - bare-metal C application
+
+[env:raspberrypi_zero]
+platform = linux_arm
+board = raspberrypi_zero
+; No framework specified - bare-metal C application
+
+[env:raspberrypi_zero2w]
+platform = linux_arm
+board = raspberrypi_zero2w
+; No framework specified - bare-metal C application

--- a/examples/baremetal-uart/src/main.c
+++ b/examples/baremetal-uart/src/main.c
@@ -1,0 +1,377 @@
+/*
+ * Bare-Metal UART Serial Communication Example
+ *
+ * Demonstrates asynchronous serial communication using Linux termios API.
+ * No GPIO library required - uses standard POSIX serial port interface.
+ *
+ * Features:
+ * - Proper termios configuration following POSIX best practices
+ * - Multiple operation modes (echo test, interactive)
+ * - Configurable baud rate
+ * - Non-blocking I/O with timeout
+ * - Comprehensive error handling
+ *
+ * Use cases:
+ * - GPS modules (NMEA data)
+ * - Bluetooth serial (HC-05, HC-06)
+ * - GSM/LTE modems (AT commands)
+ * - Serial sensors and devices
+ * - USB-to-Serial adapters
+ *
+ * Hardware connections (for hardware UART on GPIO):
+ * - TX (GPIO 14, Pin 8)  -> RX of serial device
+ * - RX (GPIO 15, Pin 10) -> TX of serial device
+ * - GND -> GND
+ *
+ * Serial devices on Raspberry Pi:
+ * - /dev/serial0 - Primary UART (symlink to ttyAMA0 or ttyS0)
+ * - /dev/ttyAMA0 - Hardware UART (GPIO 14/15 on Pi 1/2/Zero)
+ * - /dev/ttyS0 - Mini UART or Bluetooth (varies by model)
+ * - /dev/ttyUSB0 - USB-to-Serial adapter
+ * - /dev/ttyACM0 - USB CDC ACM device
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <termios.h>
+#include <sys/select.h>
+#include <sys/time.h>
+#include <time.h>
+
+// Configuration
+#define DEFAULT_DEVICE "/dev/serial0"
+#define DEFAULT_BAUD B9600
+#define BUFFER_SIZE 256
+#define TIMEOUT_SECONDS 5
+
+// ANSI color codes for better readability
+#define COLOR_RESET   "\033[0m"
+#define COLOR_GREEN   "\033[32m"
+#define COLOR_BLUE    "\033[34m"
+#define COLOR_YELLOW  "\033[33m"
+#define COLOR_RED     "\033[31m"
+#define COLOR_CYAN    "\033[36m"
+
+// Function prototypes
+int configure_serial_port(int fd, speed_t baud);
+int serial_write(int fd, const char *data, size_t len);
+int serial_read_timeout(int fd, char *buffer, size_t max_len, int timeout_sec);
+void print_usage(const char *program_name);
+void run_echo_test(int fd);
+void run_interactive_mode(int fd);
+
+int main(int argc, char *argv[]) {
+    const char *device = DEFAULT_DEVICE;
+    speed_t baud = DEFAULT_BAUD;
+    int fd;
+    int mode = 0; // 0 = echo test, 1 = interactive
+
+    // Print header
+    printf("\n");
+    printf("╔════════════════════════════════════════════════════╗\n");
+    printf("║  Bare-Metal UART Serial Communication Example     ║\n");
+    printf("║  Platform: Linux ARM (Raspberry Pi)               ║\n");
+    printf("║  API: POSIX termios (no framework required)        ║\n");
+    printf("╚════════════════════════════════════════════════════╝\n");
+    printf("\n");
+
+    // Parse command line arguments
+    if (argc > 1) {
+        if (strcmp(argv[1], "--help") == 0 || strcmp(argv[1], "-h") == 0) {
+            print_usage(argv[0]);
+            return 0;
+        }
+        if (strcmp(argv[1], "--interactive") == 0 || strcmp(argv[1], "-i") == 0) {
+            mode = 1;
+        }
+        if (argc > 2) {
+            device = argv[2];
+        }
+    }
+
+    // Display configuration
+    printf("Configuration:\n");
+    printf("  Device: %s\n", device);
+    printf("  Baud rate: 9600\n");
+    printf("  Mode: %s\n", mode == 0 ? "Echo Test" : "Interactive");
+    printf("\n");
+
+    // Open serial port
+    printf("Opening serial port...\n");
+    fd = open(device, O_RDWR | O_NOCTTY | O_NDELAY);
+    if (fd < 0) {
+        fprintf(stderr, "%s✗ Error opening %s: %s%s\n",
+                COLOR_RED, device, strerror(errno), COLOR_RESET);
+        fprintf(stderr, "\nCommon issues:\n");
+        fprintf(stderr, "  • Device not found: Check device path\n");
+        fprintf(stderr, "  • Permission denied: Run as root or add user to 'dialout' group\n");
+        fprintf(stderr, "  • UART disabled: Enable with 'sudo raspi-config' > Interface Options > Serial Port\n");
+        fprintf(stderr, "\nTry: sudo usermod -a -G dialout $USER\n");
+        fprintf(stderr, "Then log out and back in.\n");
+        return 1;
+    }
+    printf("%s✓ Serial port opened successfully%s\n", COLOR_GREEN, COLOR_RESET);
+
+    // Configure serial port
+    printf("Configuring serial parameters...\n");
+    if (configure_serial_port(fd, baud) < 0) {
+        fprintf(stderr, "%s✗ Error configuring serial port%s\n", COLOR_RED, COLOR_RESET);
+        close(fd);
+        return 1;
+    }
+    printf("%s✓ Serial port configured%s\n", COLOR_GREEN, COLOR_RESET);
+    printf("\n");
+
+    // Run selected mode
+    if (mode == 0) {
+        run_echo_test(fd);
+    } else {
+        run_interactive_mode(fd);
+    }
+
+    // Cleanup
+    close(fd);
+    printf("\n%s✓ Serial port closed%s\n", COLOR_GREEN, COLOR_RESET);
+    return 0;
+}
+
+/**
+ * Configure serial port with proper termios settings
+ * Following POSIX best practices for raw serial communication
+ */
+int configure_serial_port(int fd, speed_t baud) {
+    struct termios options;
+
+    // Get current port settings
+    if (tcgetattr(fd, &options) < 0) {
+        fprintf(stderr, "Error getting port attributes: %s\n", strerror(errno));
+        return -1;
+    }
+
+    // Set baud rate (input and output)
+    cfsetispeed(&options, baud);
+    cfsetospeed(&options, baud);
+
+    // Configure for raw input/output (no canonical mode, no echo)
+    // This is the POSIX-compliant way, not zeroing the structure
+
+    // Input flags: ignore break, no CR to NL, no parity check, no strip, no flow control
+    options.c_iflag &= ~(IGNBRK | BRKINT | ICRNL | INLCR | PARMRK | INPCK | ISTRIP | IXON);
+
+    // Output flags: no output processing
+    options.c_oflag &= ~(OCRNL | ONLCR | ONLRET | ONOCR | OFILL | OPOST);
+
+    // Line flags: no canonical mode, no echo, no signals
+    options.c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN | ISIG);
+
+    // Control flags: 8 data bits, no parity, 1 stop bit, enable receiver, local line
+    options.c_cflag &= ~(CSIZE | PARENB | CSTOPB);
+    options.c_cflag |= CS8 | CREAD | CLOCAL;
+
+    // Non-blocking read with timeout
+    // VMIN = 0: return immediately with available data
+    // VTIME = 5: timeout in deciseconds (0.5 seconds)
+    options.c_cc[VMIN] = 0;
+    options.c_cc[VTIME] = 5;
+
+    // Apply settings immediately
+    if (tcsetattr(fd, TCSANOW, &options) < 0) {
+        fprintf(stderr, "Error setting port attributes: %s\n", strerror(errno));
+        return -1;
+    }
+
+    // Flush any existing data
+    tcflush(fd, TCIOFLUSH);
+
+    return 0;
+}
+
+/**
+ * Write data to serial port
+ */
+int serial_write(int fd, const char *data, size_t len) {
+    ssize_t written = write(fd, data, len);
+    if (written < 0) {
+        fprintf(stderr, "Error writing to serial port: %s\n", strerror(errno));
+        return -1;
+    }
+    // Ensure data is transmitted
+    tcdrain(fd);
+    return written;
+}
+
+/**
+ * Read data from serial port with timeout using select()
+ */
+int serial_read_timeout(int fd, char *buffer, size_t max_len, int timeout_sec) {
+    fd_set read_fds;
+    struct timeval timeout;
+    int retval;
+
+    FD_ZERO(&read_fds);
+    FD_SET(fd, &read_fds);
+
+    timeout.tv_sec = timeout_sec;
+    timeout.tv_usec = 0;
+
+    retval = select(fd + 1, &read_fds, NULL, NULL, &timeout);
+
+    if (retval < 0) {
+        fprintf(stderr, "Error in select(): %s\n", strerror(errno));
+        return -1;
+    } else if (retval == 0) {
+        // Timeout
+        return 0;
+    }
+
+    // Data available, read it
+    return read(fd, buffer, max_len);
+}
+
+/**
+ * Echo test mode - sends test messages and displays responses
+ */
+void run_echo_test(int fd) {
+    char buffer[BUFFER_SIZE];
+    const char *test_messages[] = {
+        "Hello from Raspberry Pi!",
+        "Testing UART communication",
+        "1234567890",
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+        "Special chars: !@#$%^&*()",
+        NULL
+    };
+    int msg_idx = 0;
+    int bytes_read;
+
+    printf("╔════════════════════════════════════════════════════╗\n");
+    printf("║  Echo Test Mode                                    ║\n");
+    printf("╚════════════════════════════════════════════════════╝\n");
+    printf("\n");
+    printf("This mode sends test messages and waits for echo responses.\n");
+    printf("Connect TX to RX (loopback) or to another serial device.\n");
+    printf("\n");
+
+    while (test_messages[msg_idx] != NULL) {
+        const char *msg = test_messages[msg_idx];
+        size_t msg_len = strlen(msg);
+
+        // Send message
+        printf("%sTX:%s %s\n", COLOR_BLUE, COLOR_RESET, msg);
+        if (serial_write(fd, msg, msg_len) < 0) {
+            fprintf(stderr, "%s✗ Failed to send message%s\n", COLOR_RED, COLOR_RESET);
+            msg_idx++;
+            continue;
+        }
+
+        // Wait for response
+        printf("%sRX:%s Waiting for response", COLOR_CYAN, COLOR_RESET);
+        fflush(stdout);
+
+        memset(buffer, 0, BUFFER_SIZE);
+        bytes_read = serial_read_timeout(fd, buffer, BUFFER_SIZE - 1, TIMEOUT_SECONDS);
+
+        if (bytes_read > 0) {
+            buffer[bytes_read] = '\0';
+            printf(" -> %s%s%s", COLOR_GREEN, buffer, COLOR_RESET);
+
+            // Verify echo
+            if (strncmp(msg, buffer, msg_len) == 0) {
+                printf(" %s✓ Match%s\n", COLOR_GREEN, COLOR_RESET);
+            } else {
+                printf(" %s⚠ Mismatch%s\n", COLOR_YELLOW, COLOR_RESET);
+            }
+        } else if (bytes_read == 0) {
+            printf(" %s(timeout - no response)%s\n", COLOR_YELLOW, COLOR_RESET);
+        } else {
+            printf(" %s✗ Read error%s\n", COLOR_RED, COLOR_RESET);
+        }
+
+        printf("\n");
+        msg_idx++;
+
+        // Small delay between messages
+        usleep(500000); // 500ms
+    }
+
+    printf("%s✓ Echo test completed%s\n", COLOR_GREEN, COLOR_RESET);
+    printf("\nResults: %d messages sent\n", msg_idx);
+}
+
+/**
+ * Interactive mode - send and receive data interactively
+ */
+void run_interactive_mode(int fd) {
+    char tx_buffer[BUFFER_SIZE];
+    char rx_buffer[BUFFER_SIZE];
+    int bytes_read;
+
+    printf("╔════════════════════════════════════════════════════╗\n");
+    printf("║  Interactive Mode                                  ║\n");
+    printf("╚════════════════════════════════════════════════════╝\n");
+    printf("\n");
+    printf("Type messages to send. Press Ctrl+C to exit.\n");
+    printf("Received data will be displayed automatically.\n");
+    printf("\n");
+
+    // Set stdin to non-blocking
+    int stdin_flags = fcntl(STDIN_FILENO, F_GETFL, 0);
+    fcntl(STDIN_FILENO, F_SETFL, stdin_flags | O_NONBLOCK);
+
+    while (1) {
+        // Check for incoming serial data
+        bytes_read = serial_read_timeout(fd, rx_buffer, BUFFER_SIZE - 1, 0);
+        if (bytes_read > 0) {
+            rx_buffer[bytes_read] = '\0';
+            printf("%s<< RX:%s %s\n", COLOR_CYAN, COLOR_RESET, rx_buffer);
+            fflush(stdout);
+        }
+
+        // Check for user input
+        if (fgets(tx_buffer, BUFFER_SIZE, stdin) != NULL) {
+            size_t len = strlen(tx_buffer);
+            if (len > 0) {
+                printf("%s>> TX:%s %s", COLOR_BLUE, COLOR_RESET, tx_buffer);
+                serial_write(fd, tx_buffer, len);
+            }
+        }
+
+        // Small delay to avoid busy waiting
+        usleep(10000); // 10ms
+    }
+
+    // Restore stdin flags (won't be reached due to Ctrl+C, but good practice)
+    fcntl(STDIN_FILENO, F_SETFL, stdin_flags);
+}
+
+/**
+ * Print usage information
+ */
+void print_usage(const char *program_name) {
+    printf("Usage: %s [OPTIONS] [DEVICE]\n", program_name);
+    printf("\n");
+    printf("Options:\n");
+    printf("  -h, --help         Show this help message\n");
+    printf("  -i, --interactive  Run in interactive mode (default: echo test)\n");
+    printf("\n");
+    printf("Arguments:\n");
+    printf("  DEVICE            Serial device path (default: /dev/serial0)\n");
+    printf("\n");
+    printf("Examples:\n");
+    printf("  %s                              # Echo test on /dev/serial0\n", program_name);
+    printf("  %s --interactive                # Interactive mode\n", program_name);
+    printf("  %s /dev/ttyUSB0                # Echo test on USB serial\n", program_name);
+    printf("  %s --interactive /dev/ttyAMA0  # Interactive on hardware UART\n", program_name);
+    printf("\n");
+    printf("Common serial devices:\n");
+    printf("  /dev/serial0   - Primary UART (recommended)\n");
+    printf("  /dev/ttyAMA0   - Hardware UART (GPIO 14/15)\n");
+    printf("  /dev/ttyS0     - Mini UART or Bluetooth\n");
+    printf("  /dev/ttyUSB0   - USB-to-Serial adapter\n");
+    printf("  /dev/ttyACM0   - USB CDC ACM device\n");
+    printf("\n");
+}


### PR DESCRIPTION
Implements issue #41 - Serial UART Communication Example using bare-metal Linux termios API.

Features:
- Comprehensive UART example using POSIX termios (no framework)
- Bidirectional serial communication (echo test + interactive modes)
- Proper termios configuration following POSIX best practices
- Non-blocking I/O with select() and timeout handling
- Extensive error handling and user-friendly diagnostics
- Support for all Raspberry Pi models (1/2/3/4/5/Zero)

Technical highlights:
- 377 lines of well-documented C code
- Standard Linux serial port APIs (no WiringPi dependency)
- Cross-compilation ready
- Educational comments explaining termios flags and serial programming

Use cases:
- GPS modules (NMEA data parsing)
- Bluetooth serial (HC-05/HC-06)
- GSM/LTE modems (AT commands)
- Serial sensors and Arduino communication
- USB-to-Serial adapters

Documentation:
- 540-line comprehensive README with:
  - Hardware wiring diagrams (GPIO UART, USB-serial, loopback)
  - Raspberry Pi UART configuration (raspi-config, permissions)
  - Usage examples (echo test, interactive mode)
  - Troubleshooting guide
  - Comparison with WiringPi approach

Closes #41

# Pull Request

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

Please check the type of change your PR introduces:

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Code style update (formatting, renaming)
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🔧 Build/CI configuration change
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update

## Related Issues

<!-- Link related issues here. Use "Fixes #123" or "Closes #123" to auto-close issues -->

Fixes #
Related to #

## Checklist

Please ensure your PR meets the following requirements:

### Testing

- [ ] I have tested my changes locally
- [ ] I have built all examples successfully
- [ ] I have tested on target hardware (if applicable)
- [ ] All CI/CD checks pass
- [ ] I have tested both 32-bit and 64-bit builds (if applicable)

### Code Quality

- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors

### Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated CONTRIBUTING.md if needed
- [ ] I have updated the README.md if needed
- [ ] I have added or updated board definitions if needed
- [ ] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) specification

### Board Changes (if applicable)

- [ ] I have added/updated board definition JSON files
- [ ] I have tested the board builds successfully
- [ ] I have updated the supported boards list in README.md
- [ ] I have verified framework compatibility

### Framework Changes (if applicable)

- [ ] I have tested the framework with examples
- [ ] I have verified cross-compilation works
- [ ] I have updated framework documentation
- [ ] I have tested on multiple Pi models (if applicable)

## Test Results

<!-- Describe the tests you ran and the results -->

### Build Test Results

```bash
# Paste build test output here
```

### Runtime Test Results (if applicable)

<!-- Describe hardware testing results if you tested on actual Raspberry Pi -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here and provide migration instructions -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
