### PR TITLE
fix(build): prevent lgpio build contamination between architectures

### DIFF
--- a/scripts/setup-lgpio-cross.sh
+++ b/scripts/setup-lgpio-cross.sh
@@ -13,15 +13,18 @@ echo ""
 # Resolve script and repo directories BEFORE any cd commands
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
-BUILD_DIR="${BUILD_DIR:-/tmp/lg-build}"
 CROSS_PREFIX="${CROSS_PREFIX:-arm-linux-gnueabihf-}"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/arm-linux-gnueabihf}"
 
-# Detect architecture from cross-compiler prefix
+# Detect architecture from cross-compiler prefix and set arch-specific build dir
+# This prevents build contamination when switching between 32-bit and 64-bit builds
+# (make's timestamp-based dependency tracking doesn't detect compiler changes)
 if [[ "$CROSS_PREFIX" == "aarch64-"* ]]; then
     ARCH_NAME="ARM 64-bit (AArch64)"
+    BUILD_DIR="${BUILD_DIR:-/tmp/lg-build-aarch64}"
 else
     ARCH_NAME="ARM 32-bit (ARMv7)"
+    BUILD_DIR="${BUILD_DIR:-/tmp/lg-build-armhf}"
 fi
 
 # Check if cross-compiler is installed


### PR DESCRIPTION
Fixes #87

Use architecture-specific build directories to prevent contamination when switching between 32-bit and 64-bit ARM builds.

## Problem

The lgpio cross-compilation script used the same build directory (`/tmp/lg-build`) for both 32-bit and 64-bit builds. This caused make's timestamp-based dependency tracking to skip recompilation when switching architectures, leading to "file in wrong format" linking errors.

### Root Cause

Make checks file timestamps, not compiler settings. When switching from 32-bit to 64-bit build:
1. Make sees `.o` files newer than `.c` files
2. Make skips compilation ("Nothing to be done")
3. 64-bit linker tries to use 32-bit object files
4. Linking fails with "file in wrong format"

## Solution

Use separate build directories per architecture:
- **32-bit (ARMv7):** `/tmp/lg-build-armhf`
- **64-bit (AArch64):** `/tmp/lg-build-aarch64`

This ensures complete isolation and prevents cross-contamination.

## Changes

- Moved `BUILD_DIR` assignment to after architecture detection
- Set architecture-specific build directories based on `CROSS_PREFIX`
- Added explanatory comments about contamination prevention
- Consistent with libgpiod fix pattern

## Testing

- ✅ Both architectures build successfully in CI
- ✅ No build contamination between armhf and aarch64
- ✅ Object files are correct architecture
- ✅ Libraries link correctly

## Benefits

- ✅ Complete isolation between architectures
- ✅ No risk of contamination
- ✅ Matches professional build system patterns
- ✅ Consistent with libgpiod fix (#86)
- ✅ Enables parallel builds in the future