### PR TITLE
fix: prevent default pio device monitor from interfering with SSH mon…

### DIFF
--- a/REMOTE_TESTING.md
+++ b/REMOTE_TESTING.md
@@ -89,6 +89,10 @@ test_transport = ssh
 test_build_src = yes  ; Include src/ files in test builds
 ```
 
+**Note:** You may see a warning: `Warning! Ignore unknown configuration option 'test_transport'`.
+This is expected and harmless - PlatformIO's core schema doesn't include platform-specific
+options, but the platform correctly handles the configuration.
+
 ### 2. Set Up SSH Access
 
 ```bash

--- a/builder/main.py
+++ b/builder/main.py
@@ -229,8 +229,15 @@ def _monitor_handler(target, source, env) -> int:
         print("="*60 + "\n")
         return 0
 
-target_monitor = env.Alias("monitor", target_bin, _monitor_handler)
-AlwaysBuild(target_monitor)
+# Use AddCustomTarget to properly override PlatformIO's built-in monitor
+env.AddCustomTarget(
+    name="monitor",
+    dependencies=None,
+    actions=_monitor_handler,
+    title="Monitor",
+    description="Monitor remote program via SSH",
+    always_build=True
+)
 
 #
 # Default targets

--- a/docs/UPLOAD.md
+++ b/docs/UPLOAD.md
@@ -335,10 +335,12 @@ upload_port = pi@raspberrypi.local:/home/pi/myapp
 ```
 
 **Notes:**
-- The `monitor` target runs the program at `upload_port` location
+- The `monitor` target runs the program at `upload_port` location via SSH
 - Output is streamed in real-time from the remote target
 - Press Ctrl+C to stop monitoring
 - Unlike serial monitors, this requires a network connection to the target
+- The platform automatically configures a dummy `monitor_port` to prevent PlatformIO's
+  default serial monitor from interfering with SSH-based monitoring
 
 **Comparison with upload_run_after:**
 - `upload_run_after = true`: Runs once after each upload

--- a/platform.py
+++ b/platform.py
@@ -1094,6 +1094,9 @@ class Linux_armPlatform(PlatformBase):
                 - gdbserver-ssh: Remote debugging via SSH tunnel to gdbserver
                 - gdb-remote: Direct TCP connection to gdbserver
             Default tool is gdbserver-ssh.
+
+            Also configures monitor settings to use custom SSH-based monitoring
+            instead of default serial port monitoring.
         """
         # Lazy import to avoid breaking platform loading
         if _PLATFORM_DIR not in sys.path:
@@ -1141,6 +1144,17 @@ class Linux_armPlatform(PlatformBase):
             debug["default"] = DebugTools.DEFAULT
 
         board.manifest["debug"] = debug
+
+        # Configure monitor to use custom SSH-based monitoring (not serial ports)
+        # This prevents PlatformIO from trying to use default serial monitor
+        # Users configure monitor via upload_port instead of monitor_port
+        # Setting monitor_port to "rfc2217://localhost:0" creates a valid but
+        # non-functional RFC2217 socket that won't block or error
+        if "monitor" not in board.manifest:
+            board.manifest["monitor"] = {}
+        if "port" not in board.manifest["monitor"]:
+            board.manifest["monitor"]["port"] = "rfc2217://localhost:0"
+
         return board
 
     def on_test_upload(self, target, source, env) -> int:


### PR DESCRIPTION
…itoring

Fixes issue where running `pio run --target monitor` would show serial port list instead of using the custom SSH-based monitor.

Changes:
- builder/main.py: Use AddCustomTarget instead of Alias for monitor target to properly override PlatformIO's built-in monitor behavior
- platform.py: Add default monitor port configuration (rfc2217://localhost:0) to prevent PlatformIO from trying to use default serial monitor
- REMOTE_TESTING.md: Document test_transport warning as expected behavior
- docs/UPLOAD.md: Document automatic monitor_port configuration

The monitor target now properly uses SSH to run the remote program instead of trying to connect to local serial ports.

Note: The test_transport warning is expected - PlatformIO's core schema doesn't include platform-specific options, but they are correctly handled by the platform.

Related: #99

# Pull Request

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

Please check the type of change your PR introduces:

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Code style update (formatting, renaming)
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🔧 Build/CI configuration change
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update

## Related Issues

<!-- Link related issues here. Use "Fixes #123" or "Closes #123" to auto-close issues -->

Fixes #
Related to #

## Checklist

Please ensure your PR meets the following requirements:

### Testing

- [ ] I have tested my changes locally
- [ ] I have built all examples successfully
- [ ] I have tested on target hardware (if applicable)
- [ ] All CI/CD checks pass
- [ ] I have tested both 32-bit and 64-bit builds (if applicable)

### Code Quality

- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors

### Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated CONTRIBUTING.md if needed
- [ ] I have updated the README.md if needed
- [ ] I have added or updated board definitions if needed
- [ ] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) specification

### Board Changes (if applicable)

- [ ] I have added/updated board definition JSON files
- [ ] I have tested the board builds successfully
- [ ] I have updated the supported boards list in README.md
- [ ] I have verified framework compatibility

### Framework Changes (if applicable)

- [ ] I have tested the framework with examples
- [ ] I have verified cross-compilation works
- [ ] I have updated framework documentation
- [ ] I have tested on multiple Pi models (if applicable)

## Test Results

<!-- Describe the tests you ran and the results -->

### Build Test Results

```bash
# Paste build test output here
```

### Runtime Test Results (if applicable)

<!-- Describe hardware testing results if you tested on actual Raspberry Pi -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here and provide migration instructions -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
