### PR TITLE
Fix/v160 audit findings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
             COMMITS=$(git log --pretty=format:"- %s (%h)" --reverse)
           else
             echo "Generating changelog from $PREVIOUS_TAG to ${{ steps.version.outputs.tag }}"
-            COMMITS=$(git log $PREVIOUS_TAG..HEAD --pretty=format:"- %s (%h)" --reverse)
+            COMMITS=$(git log "$PREVIOUS_TAG"..HEAD --pretty=format:"- %s (%h)" --reverse)
           fi
 
           # Create changelog file
@@ -147,13 +147,18 @@ jobs:
           **Full Changelog**: https://github.com/${{ github.repository }}/compare/$PREVIOUS_TAG...${{ steps.version.outputs.tag }}
           EOF
 
-          # Substitute $COMMITS placeholder using Python to safely handle
+          # Substitute placeholders using Python to safely handle
           # shell metacharacters (/, &, \n) that would break sed substitution
+          export COMMITS
+          export PREVIOUS_TAG
           python3 -c "
 import os
 content = open('RELEASE_CHANGELOG.md').read()
 commits = os.environ.get('COMMITS', '')
-open('RELEASE_CHANGELOG.md', 'w').write(content.replace('\$COMMITS', commits))
+prev_tag = os.environ.get('PREVIOUS_TAG', '')
+content = content.replace('\$COMMITS', commits)
+content = content.replace('\$PREVIOUS_TAG', prev_tag)
+open('RELEASE_CHANGELOG.md', 'w').write(content)
 "
 
       - name: Install PlatformIO Core

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,9 @@ Thumbs.db
 # Claude Code session exports
 conversation.txt
 conversation.md
+
+# Backup and note files
+*.bak
+NOTES.md
+AI_NOTES.md
+AUDIT*.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
       - id: black
         language_version: python3
         args: ['--line-length=100']
-        files: ^(builder/|platform\.py)
+        files: \.py$
 
   # Python code linting
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -46,7 +46,7 @@ repos:
     hooks:
       - id: ruff
         args: ['--fix', '--exit-non-zero-on-fix']
-        files: ^(builder/|platform\.py)
+        files: \.py$
 
   # Python import sorting
   - repo: https://github.com/pycqa/isort
@@ -54,7 +54,7 @@ repos:
     hooks:
       - id: isort
         args: ['--profile=black', '--line-length=100']
-        files: ^(builder/|platform\.py)
+        files: \.py$
 
   # Markdown linting
   - repo: https://github.com/igorshubovych/markdownlint-cli

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -24,7 +24,7 @@ This document provides guidance for developers working on the platform-linux_arm
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/sfo2001/platform-linux_arm.git
+   git clone https://github.com/platformio/platform-linux_arm.git
    cd platform-linux_arm
    ```
 
@@ -470,9 +470,9 @@ mypy platform.py
 
 ## Getting Help
 
-- **Issues**: https://github.com/sfo2001/platform-linux_arm/issues
-- **Discussions**: https://github.com/sfo2001/platform-linux_arm/discussions
-- **Wiki**: https://github.com/sfo2001/platform-linux_arm/wiki
+- **Issues**: https://github.com/platformio/platform-linux_arm/issues
+- **Discussions**: https://github.com/platformio/platform-linux_arm/discussions
+- **Wiki**: https://github.com/platformio/platform-linux_arm/wiki
 
 ---
 

--- a/builder/frameworks/lgpio.py
+++ b/builder/frameworks/lgpio.py
@@ -43,12 +43,9 @@ from SCons.Script import DefaultEnvironment
 
 env = DefaultEnvironment()
 
-# Detect target architecture (same logic as builder/main.py)
-board = env.BoardConfig()
-target_arch = board.get("build.arch", "armv7")
-if env.GetProjectOption("board_build.arch", None):
-    target_arch = env.GetProjectOption("board_build.arch")
+from utils import get_target_arch
 
+target_arch = get_target_arch(env)
 is_aarch64 = target_arch == "aarch64"
 
 # Detect lgpio installation paths

--- a/builder/frameworks/libgpiod.py
+++ b/builder/frameworks/libgpiod.py
@@ -88,12 +88,9 @@ from SCons.Script import DefaultEnvironment
 
 env = DefaultEnvironment()
 
-# Detect target architecture (same logic as builder/main.py)
-board = env.BoardConfig()
-target_arch = board.get("build.arch", "armv7")
-if env.GetProjectOption("board_build.arch", None):
-    target_arch = env.GetProjectOption("board_build.arch")
+from utils import get_target_arch
 
+target_arch = get_target_arch(env)
 is_aarch64 = target_arch == "aarch64"
 
 # Detect libgpiod installation paths

--- a/builder/main.py
+++ b/builder/main.py
@@ -86,14 +86,9 @@ systype = get_systype()
 is_native = SystemType.LINUX_ARM in systype or SystemType.LINUX_AARCH64 in systype
 
 if not is_native:
-    # Detect target architecture from board configuration
-    board = env.BoardConfig()
-    target_arch = board.get("build.arch", Architecture.ARMV7)
+    from utils import get_target_arch
 
-    # Check if user explicitly set architecture via board_build.arch in platformio.ini
-    # This takes precedence over board definition
-    if env.GetProjectOption("board_build.arch", None):
-        target_arch = env.GetProjectOption("board_build.arch")
+    target_arch = get_target_arch(env)
 
     # Pi 4/5 with 64-bit OS use aarch64 architecture
     if target_arch == Architecture.AARCH64:

--- a/builder/utils.py
+++ b/builder/utils.py
@@ -1,0 +1,34 @@
+# Copyright 2014-present PlatformIO <contact@platformio.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared utilities for PlatformIO builder scripts."""
+
+
+def get_target_arch(env):
+    """Detect target architecture from board config with user override.
+
+    Reads build.arch from the board definition, then checks if the user
+    explicitly set board_build.arch in platformio.ini (which takes precedence).
+
+    Args:
+        env: PlatformIO SCons environment object.
+
+    Returns:
+        str: Target architecture identifier (e.g., "armv7", "aarch64").
+    """
+    board = env.BoardConfig()
+    target_arch = board.get("build.arch", "armv7")
+    if env.GetProjectOption("board_build.arch", None):
+        target_arch = env.GetProjectOption("board_build.arch")
+    return target_arch

--- a/platform_config.py
+++ b/platform_config.py
@@ -46,7 +46,6 @@ Example Usage:
 
 See Also:
     - Issue #73: Add Configuration File Support
-    - CLAUDE.md: Project documentation
 """
 
 import configparser

--- a/platform_constants.py
+++ b/platform_constants.py
@@ -30,8 +30,8 @@ _WINDOWS: bool = os.name == "nt"
 class SSHDefaults:
     """Default values for SSH connections and operations."""
 
-    # Default SSH port
-    PORT: Final[str] = "22"
+    # Default SSH port (int to match platform.json "number" type)
+    PORT: Final[int] = 22
 
     # Default SSH username for Raspberry Pi and similar SBCs
     USER: Final[str] = "pi"
@@ -200,7 +200,8 @@ class SSHOptions:
     STRICT_HOST_KEY_CHECKING_NO: Final[str] = "StrictHostKeyChecking=no"
 
     # Don't save host keys (for automated deployments)
-    USER_KNOWN_HOSTS_FILE_NULL: Final[str] = "UserKnownHostsFile=/dev/null"
+    # Uses os.devnull for cross-platform compatibility (/dev/null on Unix, nul on Windows)
+    USER_KNOWN_HOSTS_FILE_NULL: Final[str] = f"UserKnownHostsFile={os.devnull}"
 
     # Reduce SSH output verbosity
     LOG_LEVEL_ERROR: Final[str] = "LogLevel=ERROR"

--- a/ssh_utils.py
+++ b/ssh_utils.py
@@ -22,7 +22,7 @@ with proper shell escaping and error handling.
 
 import os
 import shlex
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 
 class SSHConnectionConfig:
@@ -32,7 +32,7 @@ class SSHConnectionConfig:
         self,
         user: str,
         host: str,
-        port: Optional[str] = None,
+        port: Optional[Union[str, int]] = None,
         key: Optional[str] = None,
         strict_host_check: bool = False,
     ):
@@ -42,7 +42,7 @@ class SSHConnectionConfig:
         Args:
             user: SSH username
             host: Remote hostname or IP address
-            port: SSH port (default: "22")
+            port: SSH port (default: 22)
             key: Path to SSH private key file (optional)
             strict_host_check: Enable strict host key checking (default: False)
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,18 +109,22 @@ upload_ssh_port = 2222
 @pytest.fixture
 def make_platform(mock_platform_manifest):
     """Factory fixture to create a Linux_armPlatform with standard mocks."""
+
     def _make(manifest=None):
-        with patch("platform_module.PlatformBase.__init__", return_value=None), \
-             patch("platform_module.get_platform_config", return_value=Mock()), \
-             patch("platform_module.Linux_armPlatform._show_welcome_if_needed"):
+        with patch("platform_module.PlatformBase.__init__", return_value=None), patch(
+            "platform_module.get_platform_config", return_value=Mock()
+        ), patch("platform_module.Linux_armPlatform._show_welcome_if_needed"):
             from platform_module import Linux_armPlatform
+
             return Linux_armPlatform(manifest or mock_platform_manifest)
+
     return _make
 
 
 @pytest.fixture
 def make_env():
     """Factory fixture to create a mock PlatformIO environment."""
+
     def _make(**overrides):
         defaults = {
             "upload_port": "pi@host:/home/pi/app",
@@ -137,4 +141,5 @@ def make_env():
             side_effect=lambda key, default=None: defaults.get(key, default)
         )
         return env
+
     return _make

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,16 +15,25 @@
 
 """Shared pytest fixtures for platform-linux_arm tests."""
 
+import importlib.util
 import os
 import sys
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 # Add parent directory to path to import platform modules
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Import platform.py module explicitly to avoid conflict with stdlib platform module
+_platform_path = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "platform.py"
+)
+spec = importlib.util.spec_from_file_location("platform_module", _platform_path)
+platform_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(platform_module)
 
 
 @pytest.fixture
@@ -95,3 +104,37 @@ upload_ssh_port = 2222
 """
     )
     return config_path
+
+
+@pytest.fixture
+def make_platform(mock_platform_manifest):
+    """Factory fixture to create a Linux_armPlatform with standard mocks."""
+    def _make(manifest=None):
+        with patch("platform_module.PlatformBase.__init__", return_value=None), \
+             patch("platform_module.get_platform_config", return_value=Mock()), \
+             patch("platform_module.Linux_armPlatform._show_welcome_if_needed"):
+            from platform_module import Linux_armPlatform
+            return Linux_armPlatform(manifest or mock_platform_manifest)
+    return _make
+
+
+@pytest.fixture
+def make_env():
+    """Factory fixture to create a mock PlatformIO environment."""
+    def _make(**overrides):
+        defaults = {
+            "upload_port": "pi@host:/home/pi/app",
+            "upload_ssh_port": None,
+            "upload_ssh_key": None,
+            "upload_flags": None,
+            "upload_strict_host_check": None,
+            "upload_timeout": None,
+            "upload_run_after": False,
+        }
+        defaults.update(overrides)
+        env = Mock()
+        env.GetProjectOption = Mock(
+            side_effect=lambda key, default=None: defaults.get(key, default)
+        )
+        return env
+    return _make

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -43,10 +43,11 @@ sys.modules["platform_module"] = platform_module
 class TestLinuxArmPlatformInit:
     """Test cases for Linux_armPlatform initialization."""
 
+    @patch("platform_module.Linux_armPlatform._show_welcome_if_needed")
     @patch("platform_module.get_platform_config")
     @patch("platform_module.PlatformBase.__init__")
     def test_init_loads_config(
-        self, mock_base_init, mock_get_config, mock_platform_manifest
+        self, mock_base_init, mock_get_config, mock_welcome, mock_platform_manifest
     ):
         """Test that initialization loads platform configuration."""
         from platform_module import Linux_armPlatform
@@ -1110,43 +1111,18 @@ class TestBuildDebugInitCommands:
 class TestUploadScp:
     """Test cases for _upload_scp method."""
 
-    def _make_platform(self, mock_platform_manifest):
-        with patch("platform_module.PlatformBase.__init__", return_value=None), patch(
-            "platform_module.get_platform_config", return_value=Mock()
-        ):
-            from platform_module import Linux_armPlatform
-
-            return Linux_armPlatform(mock_platform_manifest)
-
-    def _make_env(self, **overrides):
-        defaults = {
-            "upload_port": "pi@host:/home/pi/app",
-            "upload_ssh_port": None,
-            "upload_ssh_key": None,
-            "upload_flags": None,
-            "upload_strict_host_check": None,
-            "upload_timeout": None,
-            "upload_run_after": False,
-        }
-        defaults.update(overrides)
-        env = Mock()
-        env.GetProjectOption = Mock(
-            side_effect=lambda key, default=None: defaults.get(key, default)
-        )
-        return env
-
     @patch("platform_module.subprocess.run")
     @patch("platform_module.Linux_armPlatform._check_upload_tool")
     @patch("builtins.print")
     def test_successful_upload_returns_zero(
-        self, mock_print, mock_check_tool, mock_run, mock_platform_manifest
+        self, mock_print, mock_check_tool, mock_run, make_platform, make_env
     ):
         mock_run.return_value = Mock(returncode=0)
-        platform = self._make_platform(mock_platform_manifest)
+        platform = make_platform()
 
         source_mock = Mock()
         source_mock.__str__ = lambda self: "/local/binary"
-        env = self._make_env()
+        env = make_env()
 
         result = platform._upload_scp(Mock(), [source_mock], env)
         assert result == 0
@@ -1156,14 +1132,14 @@ class TestUploadScp:
     @patch("platform_module.Linux_armPlatform._check_upload_tool")
     @patch("builtins.print")
     def test_upload_failure_raises_exception(
-        self, mock_print, mock_check_tool, mock_run, mock_platform_manifest
+        self, mock_print, mock_check_tool, mock_run, make_platform, make_env
     ):
         mock_run.return_value = Mock(returncode=1)
-        platform = self._make_platform(mock_platform_manifest)
+        platform = make_platform()
 
         source_mock = Mock()
         source_mock.__str__ = lambda self: "/local/binary"
-        env = self._make_env()
+        env = make_env()
 
         with pytest.raises(exception.PlatformioException, match="SCP upload failed"):
             platform._upload_scp(Mock(), [source_mock], env)
@@ -1172,16 +1148,16 @@ class TestUploadScp:
     @patch("platform_module.Linux_armPlatform._check_upload_tool")
     @patch("builtins.print")
     def test_upload_timeout_raises_exception(
-        self, mock_print, mock_check_tool, mock_run, mock_platform_manifest
+        self, mock_print, mock_check_tool, mock_run, make_platform, make_env
     ):
         import subprocess
 
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="scp", timeout=120)
-        platform = self._make_platform(mock_platform_manifest)
+        platform = make_platform()
 
         source_mock = Mock()
         source_mock.__str__ = lambda self: "/local/binary"
-        env = self._make_env()
+        env = make_env()
 
         with pytest.raises(exception.PlatformioException, match="timeout"):
             platform._upload_scp(Mock(), [source_mock], env)
@@ -1196,15 +1172,16 @@ class TestUploadScp:
         mock_check_tool,
         mock_run,
         mock_run_remote,
-        mock_platform_manifest,
+        make_platform,
+        make_env,
     ):
         mock_run.return_value = Mock(returncode=0)
         mock_run_remote.return_value = 0
-        platform = self._make_platform(mock_platform_manifest)
+        platform = make_platform()
 
         source_mock = Mock()
         source_mock.__str__ = lambda self: "/local/binary"
-        env = self._make_env(upload_run_after="yes")
+        env = make_env(upload_run_after="yes")
 
         result = platform._upload_scp(Mock(), [source_mock], env)
         assert result == 0
@@ -1214,14 +1191,14 @@ class TestUploadScp:
     @patch("platform_module.Linux_armPlatform._check_upload_tool")
     @patch("builtins.print")
     def test_upload_run_after_false_skips_run_remote(
-        self, mock_print, mock_check_tool, mock_run, mock_platform_manifest
+        self, mock_print, mock_check_tool, mock_run, make_platform, make_env
     ):
         mock_run.return_value = Mock(returncode=0)
-        platform = self._make_platform(mock_platform_manifest)
+        platform = make_platform()
 
         source_mock = Mock()
         source_mock.__str__ = lambda self: "/local/binary"
-        env = self._make_env(upload_run_after=False)
+        env = make_env(upload_run_after=False)
 
         with patch.object(platform, "_run_remote_command") as mock_remote:
             result = platform._upload_scp(Mock(), [source_mock], env)
@@ -1232,43 +1209,18 @@ class TestUploadScp:
 class TestUploadRsync:
     """Test cases for _upload_rsync method."""
 
-    def _make_platform(self, mock_platform_manifest):
-        with patch("platform_module.PlatformBase.__init__", return_value=None), patch(
-            "platform_module.get_platform_config", return_value=Mock()
-        ):
-            from platform_module import Linux_armPlatform
-
-            return Linux_armPlatform(mock_platform_manifest)
-
-    def _make_env(self, **overrides):
-        defaults = {
-            "upload_port": "pi@host:/home/pi/app",
-            "upload_ssh_port": None,
-            "upload_ssh_key": None,
-            "upload_flags": None,
-            "upload_strict_host_check": None,
-            "upload_timeout": None,
-            "upload_run_after": False,
-        }
-        defaults.update(overrides)
-        env = Mock()
-        env.GetProjectOption = Mock(
-            side_effect=lambda key, default=None: defaults.get(key, default)
-        )
-        return env
-
     @patch("platform_module.subprocess.run")
     @patch("platform_module.Linux_armPlatform._check_upload_tool")
     @patch("builtins.print")
     def test_successful_upload_returns_zero(
-        self, mock_print, mock_check_tool, mock_run, mock_platform_manifest
+        self, mock_print, mock_check_tool, mock_run, make_platform, make_env
     ):
         mock_run.return_value = Mock(returncode=0)
-        platform = self._make_platform(mock_platform_manifest)
+        platform = make_platform()
 
         source_mock = Mock()
         source_mock.__str__ = lambda self: "/local/binary"
-        env = self._make_env()
+        env = make_env()
 
         result = platform._upload_rsync(Mock(), [source_mock], env)
         assert result == 0
@@ -1278,14 +1230,14 @@ class TestUploadRsync:
     @patch("platform_module.Linux_armPlatform._check_upload_tool")
     @patch("builtins.print")
     def test_upload_failure_raises_exception(
-        self, mock_print, mock_check_tool, mock_run, mock_platform_manifest
+        self, mock_print, mock_check_tool, mock_run, make_platform, make_env
     ):
         mock_run.return_value = Mock(returncode=1)
-        platform = self._make_platform(mock_platform_manifest)
+        platform = make_platform()
 
         source_mock = Mock()
         source_mock.__str__ = lambda self: "/local/binary"
-        env = self._make_env()
+        env = make_env()
 
         with pytest.raises(exception.PlatformioException, match="Rsync upload failed"):
             platform._upload_rsync(Mock(), [source_mock], env)
@@ -1294,16 +1246,16 @@ class TestUploadRsync:
     @patch("platform_module.Linux_armPlatform._check_upload_tool")
     @patch("builtins.print")
     def test_upload_timeout_raises_exception(
-        self, mock_print, mock_check_tool, mock_run, mock_platform_manifest
+        self, mock_print, mock_check_tool, mock_run, make_platform, make_env
     ):
         import subprocess
 
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="rsync", timeout=120)
-        platform = self._make_platform(mock_platform_manifest)
+        platform = make_platform()
 
         source_mock = Mock()
         source_mock.__str__ = lambda self: "/local/binary"
-        env = self._make_env()
+        env = make_env()
 
         with pytest.raises(exception.PlatformioException, match="timeout"):
             platform._upload_rsync(Mock(), [source_mock], env)
@@ -1318,15 +1270,16 @@ class TestUploadRsync:
         mock_check_tool,
         mock_run,
         mock_run_remote,
-        mock_platform_manifest,
+        make_platform,
+        make_env,
     ):
         mock_run.return_value = Mock(returncode=0)
         mock_run_remote.return_value = 0
-        platform = self._make_platform(mock_platform_manifest)
+        platform = make_platform()
 
         source_mock = Mock()
         source_mock.__str__ = lambda self: "/local/binary"
-        env = self._make_env(upload_run_after="yes")
+        env = make_env(upload_run_after="yes")
 
         result = platform._upload_rsync(Mock(), [source_mock], env)
         assert result == 0
@@ -1336,44 +1289,19 @@ class TestUploadRsync:
 class TestUploadSsh:
     """Test cases for _upload_ssh method."""
 
-    def _make_platform(self, mock_platform_manifest):
-        with patch("platform_module.PlatformBase.__init__", return_value=None), patch(
-            "platform_module.get_platform_config", return_value=Mock()
-        ):
-            from platform_module import Linux_armPlatform
-
-            return Linux_armPlatform(mock_platform_manifest)
-
-    def _make_env(self, **overrides):
-        defaults = {
-            "upload_port": "pi@host:/home/pi/app",
-            "upload_ssh_port": None,
-            "upload_ssh_key": None,
-            "upload_flags": None,
-            "upload_strict_host_check": None,
-            "upload_timeout": None,
-            "upload_run_after": False,
-        }
-        defaults.update(overrides)
-        env = Mock()
-        env.GetProjectOption = Mock(
-            side_effect=lambda key, default=None: defaults.get(key, default)
-        )
-        return env
-
     @patch("builtins.open", mock_open(read_data=b"\x00\x01\x02"))
     @patch("platform_module.subprocess.run")
     @patch("platform_module.Linux_armPlatform._check_upload_tool")
     @patch("builtins.print")
     def test_successful_upload_returns_zero(
-        self, mock_print, mock_check_tool, mock_run, mock_platform_manifest
+        self, mock_print, mock_check_tool, mock_run, make_platform, make_env
     ):
         mock_run.return_value = Mock(returncode=0)
-        platform = self._make_platform(mock_platform_manifest)
+        platform = make_platform()
 
         source_mock = Mock()
         source_mock.__str__ = lambda self: "/local/binary"
-        env = self._make_env()
+        env = make_env()
 
         result = platform._upload_ssh(Mock(), [source_mock], env)
         assert result == 0
@@ -1384,14 +1312,14 @@ class TestUploadSsh:
     @patch("platform_module.Linux_armPlatform._check_upload_tool")
     @patch("builtins.print")
     def test_upload_failure_raises_exception(
-        self, mock_print, mock_check_tool, mock_run, mock_platform_manifest
+        self, mock_print, mock_check_tool, mock_run, make_platform, make_env
     ):
         mock_run.return_value = Mock(returncode=1)
-        platform = self._make_platform(mock_platform_manifest)
+        platform = make_platform()
 
         source_mock = Mock()
         source_mock.__str__ = lambda self: "/local/binary"
-        env = self._make_env()
+        env = make_env()
 
         with pytest.raises(exception.PlatformioException, match="SSH upload failed"):
             platform._upload_ssh(Mock(), [source_mock], env)
@@ -1401,16 +1329,16 @@ class TestUploadSsh:
     @patch("platform_module.Linux_armPlatform._check_upload_tool")
     @patch("builtins.print")
     def test_upload_timeout_raises_exception(
-        self, mock_print, mock_check_tool, mock_run, mock_platform_manifest
+        self, mock_print, mock_check_tool, mock_run, make_platform, make_env
     ):
         import subprocess
 
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="ssh", timeout=120)
-        platform = self._make_platform(mock_platform_manifest)
+        platform = make_platform()
 
         source_mock = Mock()
         source_mock.__str__ = lambda self: "/local/binary"
-        env = self._make_env()
+        env = make_env()
 
         with pytest.raises(exception.PlatformioException, match="timeout"):
             platform._upload_ssh(Mock(), [source_mock], env)
@@ -1426,15 +1354,16 @@ class TestUploadSsh:
         mock_check_tool,
         mock_run,
         mock_run_remote,
-        mock_platform_manifest,
+        make_platform,
+        make_env,
     ):
         mock_run.return_value = Mock(returncode=0)
         mock_run_remote.return_value = 0
-        platform = self._make_platform(mock_platform_manifest)
+        platform = make_platform()
 
         source_mock = Mock()
         source_mock.__str__ = lambda self: "/local/binary"
-        env = self._make_env(upload_run_after="yes")
+        env = make_env(upload_run_after="yes")
 
         result = platform._upload_ssh(Mock(), [source_mock], env)
         assert result == 0
@@ -1444,35 +1373,14 @@ class TestUploadSsh:
 class TestRunRemoteCommand:
     """Test cases for _run_remote_command method."""
 
-    def _make_platform(self, mock_platform_manifest):
-        with patch("platform_module.PlatformBase.__init__", return_value=None), patch(
-            "platform_module.get_platform_config", return_value=Mock()
-        ):
-            from platform_module import Linux_armPlatform
-
-            return Linux_armPlatform(mock_platform_manifest)
-
-    def _make_env(self, **overrides):
-        defaults = {
-            "upload_strict_host_check": None,
-            "upload_run_command": None,
-            "upload_run_timeout": None,
-        }
-        defaults.update(overrides)
-        env = Mock()
-        env.GetProjectOption = Mock(
-            side_effect=lambda key, default=None: defaults.get(key, default)
-        )
-        return env
-
     @patch("platform_module.subprocess.run")
     @patch("builtins.print")
     def test_successful_run_returns_zero(
-        self, mock_print, mock_run, mock_platform_manifest
+        self, mock_print, mock_run, make_platform, make_env
     ):
         mock_run.return_value = Mock(returncode=0)
-        platform = self._make_platform(mock_platform_manifest)
-        env = self._make_env()
+        platform = make_platform()
+        env = make_env()
 
         result = platform._run_remote_command(
             "pi", "host", "22", None, "/home/pi/app", env
@@ -1482,11 +1390,11 @@ class TestRunRemoteCommand:
     @patch("platform_module.subprocess.run")
     @patch("builtins.print")
     def test_nonzero_exit_code_returned(
-        self, mock_print, mock_run, mock_platform_manifest
+        self, mock_print, mock_run, make_platform, make_env
     ):
         mock_run.return_value = Mock(returncode=42)
-        platform = self._make_platform(mock_platform_manifest)
-        env = self._make_env()
+        platform = make_platform()
+        env = make_env()
 
         result = platform._run_remote_command(
             "pi", "host", "22", None, "/home/pi/app", env
@@ -1496,13 +1404,13 @@ class TestRunRemoteCommand:
     @patch("platform_module.subprocess.run")
     @patch("builtins.print")
     def test_timeout_raises_exception(
-        self, mock_print, mock_run, mock_platform_manifest
+        self, mock_print, mock_run, make_platform, make_env
     ):
         import subprocess
 
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="ssh", timeout=300)
-        platform = self._make_platform(mock_platform_manifest)
-        env = self._make_env()
+        platform = make_platform()
+        env = make_env()
 
         with pytest.raises(exception.PlatformioException, match="timeout"):
             platform._run_remote_command("pi", "host", "22", None, "/home/pi/app", env)
@@ -1510,11 +1418,11 @@ class TestRunRemoteCommand:
     @patch("platform_module.subprocess.run")
     @patch("builtins.print")
     def test_custom_run_command_used(
-        self, mock_print, mock_run, mock_platform_manifest
+        self, mock_print, mock_run, make_platform, make_env
     ):
         mock_run.return_value = Mock(returncode=0)
-        platform = self._make_platform(mock_platform_manifest)
-        env = self._make_env(upload_run_command="sudo /opt/myapp --daemon")
+        platform = make_platform()
+        env = make_env(upload_run_command="sudo /opt/myapp --daemon")
 
         platform._run_remote_command("pi", "host", "22", None, "/home/pi/app", env)
 
@@ -1525,11 +1433,11 @@ class TestRunRemoteCommand:
     @patch("platform_module.subprocess.run")
     @patch("builtins.print")
     def test_directory_path_appends_program_name(
-        self, mock_print, mock_run, mock_platform_manifest
+        self, mock_print, mock_run, make_platform, make_env
     ):
         mock_run.return_value = Mock(returncode=0)
-        platform = self._make_platform(mock_platform_manifest)
-        env = self._make_env()
+        platform = make_platform()
+        env = make_env()
 
         source_mock = Mock()
         source_mock.__str__ = lambda self: "/local/build/myapp"
@@ -1547,16 +1455,8 @@ class TestRunRemoteCommand:
 class TestParseDebugConnectionInfo:
     """Test _parse_debug_connection_info extracts connection details correctly."""
 
-    def _make_platform(self, mock_platform_manifest):
-        with patch("platform_module.PlatformBase.__init__", return_value=None), patch(
-            "platform_module.get_platform_config", return_value=Mock()
-        ):
-            from platform_module import Linux_armPlatform
-
-            return Linux_armPlatform(mock_platform_manifest)
-
-    def test_parses_full_upload_port(self, mock_platform_manifest):
-        platform = self._make_platform(mock_platform_manifest)
+    def test_parses_full_upload_port(self, make_platform):
+        platform = make_platform()
 
         debug_config = Mock()
         debug_config.env_options = {
@@ -1572,10 +1472,10 @@ class TestParseDebugConnectionInfo:
         assert host == "myhost.local"
         assert prog_path == "/opt/myapp"
 
-    def test_defaults_when_minimal_config(self, mock_platform_manifest):
+    def test_defaults_when_minimal_config(self, make_platform):
         from platform_constants import SSHDefaults
 
-        platform = self._make_platform(mock_platform_manifest)
+        platform = make_platform()
 
         debug_config = Mock()
         debug_config.env_options = {}
@@ -1590,8 +1490,8 @@ class TestParseDebugConnectionInfo:
         assert ssh_port == SSHDefaults.PORT
         assert ssh_key is None
 
-    def test_directory_path_appends_program_name(self, mock_platform_manifest):
-        platform = self._make_platform(mock_platform_manifest)
+    def test_directory_path_appends_program_name(self, make_platform):
+        platform = make_platform()
 
         debug_config = Mock()
         debug_config.env_options = {
@@ -1605,8 +1505,8 @@ class TestParseDebugConnectionInfo:
 
         assert prog_path == "/home/pi/bin/myapp"
 
-    def test_custom_ssh_port_and_key(self, mock_platform_manifest):
-        platform = self._make_platform(mock_platform_manifest)
+    def test_custom_ssh_port_and_key(self, make_platform):
+        platform = make_platform()
 
         debug_config = Mock()
         debug_config.env_options = {
@@ -1623,8 +1523,8 @@ class TestParseDebugConnectionInfo:
         assert ssh_port == "2222"
         assert ssh_key == "/home/user/.ssh/custom_key"
 
-    def test_upload_port_takes_precedence_over_debug_port(self, mock_platform_manifest):
-        platform = self._make_platform(mock_platform_manifest)
+    def test_upload_port_takes_precedence_over_debug_port(self, make_platform):
+        platform = make_platform()
 
         debug_config = Mock()
         debug_config.env_options = {

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1541,7 +1541,6 @@ class TestParseDebugConnectionInfo:
         assert host == "upload-host"
         assert prog_path == "/app"
 
-
     def test_fallback_at_sign_parsing(self, make_platform):
         """Test fallback parsing when parse_upload_port raises ValueError."""
         platform = make_platform()
@@ -1600,9 +1599,11 @@ class TestShowWelcomeIfNeeded:
 
     def _make_platform_raw(self, mock_platform_manifest):
         """Create platform WITHOUT patching _show_welcome_if_needed."""
-        with patch("platform_module.PlatformBase.__init__", return_value=None), \
-             patch("platform_module.get_platform_config", return_value=Mock()):
+        with patch("platform_module.PlatformBase.__init__", return_value=None), patch(
+            "platform_module.get_platform_config", return_value=Mock()
+        ):
             from platform_module import Linux_armPlatform
+
             return Linux_armPlatform(mock_platform_manifest)
 
     @patch("builtins.print")

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1542,6 +1542,108 @@ class TestParseDebugConnectionInfo:
         assert prog_path == "/app"
 
 
+    def test_fallback_at_sign_parsing(self, make_platform):
+        """Test fallback parsing when parse_upload_port raises ValueError."""
+        platform = make_platform()
+
+        debug_config = Mock()
+        debug_config.env_options = {
+            "upload_port": "pi@somehost",
+        }
+        debug_config.build_data = {}
+
+        with patch("ssh_utils.parse_upload_port", side_effect=ValueError("bad")):
+            user, host, prog_path, ssh_port, ssh_key = (
+                platform._parse_debug_connection_info(debug_config)
+            )
+
+        assert user == "pi"
+        assert host == "somehost"
+
+    def test_fallback_host_only_no_at(self, make_platform):
+        """Test fallback parsing for host-only format without @ sign."""
+        platform = make_platform()
+
+        debug_config = Mock()
+        debug_config.env_options = {
+            "upload_port": "myhost:3333",
+        }
+        debug_config.build_data = {}
+
+        with patch("ssh_utils.parse_upload_port", side_effect=ValueError("bad")):
+            user, host, prog_path, ssh_port, ssh_key = (
+                platform._parse_debug_connection_info(debug_config)
+            )
+
+        assert host == "myhost"
+
+    def test_debug_port_used_when_no_upload_port(self, make_platform):
+        """Test debug_port is used when upload_port is not set."""
+        platform = make_platform()
+
+        debug_config = Mock()
+        debug_config.env_options = {
+            "debug_port": "pi@debug-host:/debug-app",
+        }
+        debug_config.build_data = {}
+
+        user, host, prog_path, ssh_port, ssh_key = (
+            platform._parse_debug_connection_info(debug_config)
+        )
+
+        assert host == "debug-host"
+        assert prog_path == "/debug-app"
+
+
+class TestShowWelcomeIfNeeded:
+    """Test _show_welcome_if_needed first-run welcome message."""
+
+    def _make_platform_raw(self, mock_platform_manifest):
+        """Create platform WITHOUT patching _show_welcome_if_needed."""
+        with patch("platform_module.PlatformBase.__init__", return_value=None), \
+             patch("platform_module.get_platform_config", return_value=Mock()):
+            from platform_module import Linux_armPlatform
+            return Linux_armPlatform(mock_platform_manifest)
+
+    @patch("builtins.print")
+    @patch("os.path.exists", return_value=False)
+    @patch("pathlib.Path.touch")
+    def test_first_run_shows_message(
+        self, mock_touch, mock_exists, mock_print, mock_platform_manifest
+    ):
+        platform = self._make_platform_raw(mock_platform_manifest)
+        platform._show_welcome_if_needed()
+
+        # Should have printed the welcome banner
+        print_calls = [str(c) for c in mock_print.call_args_list]
+        assert any("Welcome" in c for c in print_calls)
+        assert mock_touch.called
+
+    @patch("builtins.print")
+    @patch("os.path.exists", return_value=True)
+    def test_second_run_skips_message(
+        self, mock_exists, mock_print, mock_platform_manifest
+    ):
+        platform = self._make_platform_raw(mock_platform_manifest)
+        platform._show_welcome_if_needed()
+
+        # Should NOT print anything when marker exists
+        mock_print.assert_not_called()
+
+    @patch("builtins.print")
+    @patch("os.path.exists", return_value=False)
+    @patch("pathlib.Path.touch", side_effect=OSError("permission denied"))
+    def test_marker_write_failure_still_shows_message(
+        self, mock_touch, mock_exists, mock_print, mock_platform_manifest
+    ):
+        platform = self._make_platform_raw(mock_platform_manifest)
+        platform._show_welcome_if_needed()
+
+        # Should still show message even if marker file can't be written
+        print_calls = [str(c) for c in mock_print.call_args_list]
+        assert any("Welcome" in c for c in print_calls)
+
+
 class TestPosixPathUsage:
     """Verify remote paths always use forward slashes (posixpath, not os.path)."""
 

--- a/tests/test_platform_config.py
+++ b/tests/test_platform_config.py
@@ -7,8 +7,6 @@ Tests the PlatformConfig class and configuration file loading functionality.
 
 import os
 import sys
-import tempfile
-import unittest
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -19,36 +17,26 @@ import platform_config as _pc_module
 from platform_config import PlatformConfig, parse_bool_option
 
 
-class TestPlatformConfig(unittest.TestCase):
+class TestPlatformConfig:
     """Test cases for PlatformConfig class."""
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path):
         """Set up test fixtures."""
-        self.temp_dir = tempfile.mkdtemp()
-        self.addCleanup(lambda: self._cleanup_temp_dir())
+        self.temp_dir = str(tmp_path)
         # Reset the module-level singleton so tests don't share state
         _pc_module._global_config_instance = None
-
-    def tearDown(self):
-        """Reset singleton after each test."""
+        yield
         _pc_module._global_config_instance = None
-        self._cleanup_temp_dir()
-
-    def _cleanup_temp_dir(self):
-        """Clean up temporary directory."""
-        import shutil
-
-        if os.path.exists(self.temp_dir):
-            shutil.rmtree(self.temp_dir)
 
     def test_empty_config(self):
         """Test with no configuration files."""
         config = PlatformConfig(project_dir=self.temp_dir)
 
         # Should return default values when no config exists
-        self.assertEqual(config.get("upload_timeout", 300), 300)
-        self.assertEqual(config.get("upload_user", "pi"), "pi")
-        self.assertEqual(len(config.get_loaded_files()), 0)
+        assert config.get("upload_timeout", 300) == 300
+        assert config.get("upload_user", "pi") == "pi"
+        assert len(config.get_loaded_files()) == 0
 
     def test_project_config_loading(self):
         """Test loading project-local configuration."""
@@ -65,10 +53,10 @@ upload_ssh_port = 2222
         config = PlatformConfig(project_dir=self.temp_dir)
 
         # Should load values from project config
-        self.assertEqual(config.get("upload_timeout", 300), 600)
-        self.assertEqual(config.get("upload_user", "pi"), "admin")
-        self.assertEqual(config.get("upload_ssh_port", "22"), "2222")
-        self.assertEqual(len(config.get_loaded_files()), 1)
+        assert config.get("upload_timeout", 300) == 600
+        assert config.get("upload_user", "pi") == "admin"
+        assert config.get("upload_ssh_port", "22") == "2222"
+        assert len(config.get_loaded_files()) == 1
 
     def test_type_conversion_int(self):
         """Test integer type conversion."""
@@ -84,8 +72,8 @@ test_timeout = 1200
 
         # Should convert to int when default is int
         timeout = config.get("upload_timeout", 300)
-        self.assertIsInstance(timeout, int)
-        self.assertEqual(timeout, 600)
+        assert isinstance(timeout, int)
+        assert timeout == 600
 
     def test_type_conversion_bool(self):
         """Test boolean type conversion."""
@@ -101,9 +89,9 @@ test_flag = yes
         config = PlatformConfig(project_dir=self.temp_dir)
 
         # Should convert to bool when default is bool
-        self.assertEqual(config.get("upload_run_after", False), True)
-        self.assertEqual(config.get("debug_enabled", True), False)
-        self.assertEqual(config.get("test_flag", False), True)
+        assert config.get("upload_run_after", False) is True
+        assert config.get("debug_enabled", True) is False
+        assert config.get("test_flag", False) is True
 
     def test_type_conversion_string(self):
         """Test string type preservation."""
@@ -119,22 +107,20 @@ upload_path = /opt/myapp
 
         # Should preserve as string when default is string
         user = config.get("upload_user", "pi")
-        self.assertIsInstance(user, str)
-        self.assertEqual(user, "testuser")
+        assert isinstance(user, str)
+        assert user == "testuser"
 
     def test_invalid_config_file(self):
         """Test handling of invalid config file."""
         config_path = Path(self.temp_dir) / ".platform-linux_arm.ini"
         # A key=value line without a section header reliably triggers
         # configparser.MissingSectionHeaderError on all Python versions
-        self.assertTrue(
-            config_path.parent.exists(), "temp dir should exist before writing"
-        )
+        assert config_path.parent.exists(), "temp dir should exist before writing"
         config_path.write_text("key = value_without_section\n")
 
         # Should not raise exception, just ignore invalid file
         config = PlatformConfig(project_dir=self.temp_dir)
-        self.assertEqual(config.get("upload_timeout", 300), 300)
+        assert config.get("upload_timeout", 300) == 300
 
     def test_get_all(self):
         """Test get_all method."""
@@ -149,9 +135,9 @@ upload_user = admin
         config = PlatformConfig(project_dir=self.temp_dir)
         all_config = config.get_all()
 
-        self.assertEqual(len(all_config), 2)
-        self.assertIn("upload_timeout", all_config)
-        self.assertIn("upload_user", all_config)
+        assert len(all_config) == 2
+        assert "upload_timeout" in all_config
+        assert "upload_user" in all_config
 
     def test_missing_defaults_section(self):
         """Test config file without [defaults] section."""
@@ -165,8 +151,8 @@ upload_timeout = 600
         config = PlatformConfig(project_dir=self.temp_dir)
 
         # Should not load values from other sections
-        self.assertEqual(config.get("upload_timeout", 300), 300)
-        self.assertEqual(len(config.get_loaded_files()), 0)
+        assert config.get("upload_timeout", 300) == 300
+        assert len(config.get_loaded_files()) == 0
 
     def test_multiple_config_values(self):
         """Test loading multiple configuration values."""
@@ -183,96 +169,87 @@ test_username = testuser
 
         config = PlatformConfig(project_dir=self.temp_dir)
 
-        self.assertEqual(config.get("upload_timeout", 300), 600)
-        self.assertEqual(config.get("upload_user", "pi"), "admin")
-        self.assertEqual(config.get("upload_ssh_port", "22"), "2222")
-        self.assertEqual(config.get("test_timeout", 600), 1200)
-        self.assertEqual(config.get("test_username", "pi"), "testuser")
+        assert config.get("upload_timeout", 300) == 600
+        assert config.get("upload_user", "pi") == "admin"
+        assert config.get("upload_ssh_port", "22") == "2222"
+        assert config.get("test_timeout", 600) == 1200
+        assert config.get("test_username", "pi") == "testuser"
 
 
-class TestConfigIntegration(unittest.TestCase):
+class TestConfigIntegration:
     """Integration tests for configuration system."""
 
-    def test_backward_compatibility(self):
+    def test_backward_compatibility(self, tmp_path):
         """Test that missing config files don't break anything."""
-        # Create a temporary directory with no config files
-        with tempfile.TemporaryDirectory() as temp_dir:
-            config = PlatformConfig(project_dir=temp_dir)
+        config = PlatformConfig(project_dir=str(tmp_path))
 
-            # Should work fine with defaults
-            self.assertEqual(config.get("upload_timeout", 300), 300)
-            self.assertEqual(config.get("upload_user", "pi"), "pi")
-            self.assertEqual(len(config.get_loaded_files()), 0)
+        # Should work fine with defaults
+        assert config.get("upload_timeout", 300) == 300
+        assert config.get("upload_user", "pi") == "pi"
+        assert len(config.get_loaded_files()) == 0
 
     def test_config_file_example(self):
         """Test that the example config file is valid."""
         example_path = Path(__file__).parent.parent / ".platform-linux_arm.ini.example"
 
         if not example_path.exists():
-            self.skipTest(f"Example config file not found: {example_path}")
+            pytest.skip(f"Example config file not found: {example_path}")
 
         # Should be readable and parseable (even though we won't load it as config)
         content = example_path.read_text()
-        self.assertIn("[defaults]", content)
-        self.assertIn("upload_timeout", content)
-        self.assertIn("upload_user", content)
+        assert "[defaults]" in content
+        assert "upload_timeout" in content
+        assert "upload_user" in content
 
 
-class TestPlatformConfigEnvVar(unittest.TestCase):
+class TestPlatformConfigEnvVar:
     """Test environment variable interaction for PlatformConfig."""
 
-    def setUp(self):
-        self.temp_dir = tempfile.mkdtemp()
-        self.addCleanup(self._cleanup)
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path):
+        """Set up test fixtures."""
+        self.temp_dir = str(tmp_path)
         _pc_module._global_config_instance = None
-
-    def tearDown(self):
+        yield
         _pc_module._global_config_instance = None
-
-    def _cleanup(self):
-        import shutil
-
         _env_key = "PLATFORMIO_CORE_DIR"
         if _env_key in os.environ:
             del os.environ[_env_key]
-        if os.path.exists(self.temp_dir):
-            shutil.rmtree(self.temp_dir)
 
     def test_global_config_path_respects_env_var(self):
         """PLATFORMIO_CORE_DIR controls the global config path."""
         os.environ["PLATFORMIO_CORE_DIR"] = self.temp_dir
         config = PlatformConfig(project_dir=self.temp_dir)
         global_path = config._get_global_config_path()
-        self.assertEqual(str(global_path.parent), self.temp_dir)
+        assert str(global_path.parent) == self.temp_dir
 
-    def test_project_config_overrides_global_config(self):
+    def test_project_config_overrides_global_config(self, tmp_path):
         """Project-local config takes priority over global config for the same key."""
         # Global config: upload_timeout = 100
-        global_dir = tempfile.mkdtemp()
-        self.addCleanup(
-            lambda: __import__("shutil").rmtree(global_dir, ignore_errors=True)
-        )
-        global_config = Path(global_dir) / ".platform-linux_arm.ini"
+        global_dir = tmp_path / "global"
+        global_dir.mkdir()
+        global_config = global_dir / ".platform-linux_arm.ini"
         global_config.write_text("[defaults]\nupload_timeout = 100\n")
 
         # Project config: upload_timeout = 999
         project_config = Path(self.temp_dir) / ".platform-linux_arm.ini"
         project_config.write_text("[defaults]\nupload_timeout = 999\n")
 
-        os.environ["PLATFORMIO_CORE_DIR"] = global_dir
+        os.environ["PLATFORMIO_CORE_DIR"] = str(global_dir)
         config = PlatformConfig(project_dir=self.temp_dir)
 
         # Project-local value must win (int conversion because default is int)
-        self.assertEqual(config.get("upload_timeout", 300), 999)
+        assert config.get("upload_timeout", 300) == 999
 
 
-class TestSingletonIsolation(unittest.TestCase):
+class TestSingletonIsolation:
     """Verify that get_platform_config() singleton resets correctly between tests."""
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test fixtures."""
         _pc_module._global_config_instance = None
-
-    def tearDown(self):
+        yield
         _pc_module._global_config_instance = None
 
     def test_singleton_returns_same_instance(self):
@@ -281,11 +258,11 @@ class TestSingletonIsolation(unittest.TestCase):
 
         first = get_platform_config()
         second = get_platform_config()
-        self.assertIs(first, second)
+        assert first is second
 
     def test_singleton_resets_between_tests(self):
         """setUp resets the singleton so each test starts with a fresh instance."""
-        self.assertIsNone(_pc_module._global_config_instance)
+        assert _pc_module._global_config_instance is None
 
 
 class TestParseBoolOption:
@@ -313,4 +290,4 @@ class TestParseBoolOption:
 
 
 if __name__ == "__main__":
-    unittest.main()
+    pytest.main([__file__, "-v"])

--- a/tests/test_ssh_utils.py
+++ b/tests/test_ssh_utils.py
@@ -37,7 +37,7 @@ class TestSSHConnectionConfig:
 
         assert config.user == "testuser"
         assert config.host == "testhost"
-        assert config.port == "22"
+        assert config.port == 22
         assert config.key is None
         assert config.strict_host_check is False
 


### PR DESCRIPTION
# Pull Request


## Summary
 
Addresses findings from a comprehensive 4-agent PR audit of the develop branch against upstream v1.6.0. Fixes blocking, high-priority, and recommended issues across CI, platform constants, builder architecture, test infrastructure, docum>
  
## Blocking fixes 
 
- fix(ci): COMMITS and PREVIOUS_TAG shell variables were never exported before the Python subprocess in release.yml, causing all release changelogs to be empty. Also quotes $PREVIOUS_TAG for shell safety.
- fix(platform): SSHDefaults.PORT was str "22" but platform.json declares it as type: "number" — changed to int 22 to match PlatformIO runtime behavior.
- fix(platform): UserKnownHostsFile=/dev/null hardcoded — replaced with os.devnull for Windows compatibility (nul on Windows).
- git cleanup: Deleted backup-pre-squash-20260328 tag, purged 282 local refs/replace/ objects, removed stale branches.
 
## High-priority improvements 

- refactor(test): Consolidated 5 duplicate _make_platform and 4 duplicate _make_env helpers into shared conftest.py fixtures.
- refactor(test): _show_welcome_if_needed now patched in all tests that instantiate Linux_armPlatform, preventing filesystem side effects (marker file writes to ~/.platformio/).
- refactor(test): Migrated 4 unittest.TestCase classes in test_platform_config.py to native pytest style.
- docs: Removed private CLAUDE.md reference from platform_config.py docstring.

## Recommended improvements 

- refactor(builder): Extracted duplicated architecture detection logic from builder/main.py, lgpio.py, and libgpiod.py into shared builder/utils.py.
- test: Added coverage for _parse_debug_connection_info fallback parsing (ValueError/at-sign/host-only) and _show_welcome_if_needed (first-run, repeat-run, write-failure).
- docs: Replaced fork URLs with upstream URLs in DEVELOPER.md.
- chore: Added defensive .gitignore entries for backup and note files.

## Test plan  

- All 190 tests pass locally (was 184, +6 new)
- No test logic changed — only infrastructure/style in commit 4
- Verified SSHDefaults.PORT type change has no downstream breakage (str() coercion already in place)
- Verified os.devnull produces correct value on Linux (/dev/null)
- CI pipeline passes on Ubuntu, macOS, and Windows
- Verify Windows CI handles UserKnownHostsFile=nul correctly with OpenSSH

AI-assisted: This PR was developed with AI assistance (Claude Code). Disclosed per CONTRIBUTING.md.
