### PR TITLE
fix(community): SECURITY.md naming, issue templates, CoC, AI contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug Report
+about: Something isn't working as expected
+title: 'bug: '
+labels: bug
+assignees: ''
+---
+
+## Environment
+
+| Field | Value |
+|-------|-------|
+| **Platform version** | <!-- e.g. 1.9.0 --> |
+| **PlatformIO Core version** | <!-- `pio --version` --> |
+| **Host OS** | <!-- Ubuntu 24.04 / macOS 15 / Windows 11 --> |
+| **Board** | <!-- e.g. raspberrypi_4b / arduino_uno_q --> |
+| **Framework** | <!-- e.g. lgpio / libgpiod / arduino-bridge --> |
+
+## Description
+
+<!-- What went wrong? -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behaviour
+
+<!-- What should have happened? -->
+
+## Actual Behaviour
+
+<!-- What happened instead? Include full error output. -->
+
+```
+paste error output here
+```
+
+## platformio.ini
+
+```ini
+paste your platformio.ini here
+```
+
+## Additional Context
+
+<!-- Logs, screenshots, hardware setup, anything else relevant. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://github.com/sfo2001/platform-linux_arm/wiki
+    about: Check the wiki before opening an issue
+  - name: Discussions
+    url: https://github.com/sfo2001/platform-linux_arm/discussions
+    about: Questions and general discussion

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature Request
+about: Suggest a new board, framework, example, or platform improvement
+title: 'feat: '
+labels: enhancement
+assignees: ''
+---
+
+## Summary
+
+<!-- One sentence: what do you want added or changed? -->
+
+## Motivation
+
+<!-- Why is this useful? What problem does it solve? -->
+
+## Proposed Solution
+
+<!-- How should it work? API, configuration, behaviour. -->
+
+## Alternatives Considered
+
+<!-- Other approaches you've thought about. -->
+
+## Additional Context
+
+<!-- Links, references, prior art, related issues. -->

--- a/.github/ISSUE_TEMPLATE/hardware_validation.md
+++ b/.github/ISSUE_TEMPLATE/hardware_validation.md
@@ -1,0 +1,58 @@
+---
+name: Hardware Validation Report
+about: Report test results on physical hardware (Arduino Uno Q, new boards, etc.)
+title: 'hw-validation: '
+labels: hardware-validation
+assignees: ''
+---
+
+## Hardware Under Test
+
+| Field | Value |
+|-------|-------|
+| **Board** | <!-- e.g. Arduino Uno Q / Raspberry Pi 5 --> |
+| **Board revision / serial** | <!-- if known --> |
+| **Platform version** | <!-- e.g. 1.9.0 --> |
+| **Framework** | <!-- e.g. arduino-bridge / lgpio --> |
+| **Example tested** | <!-- e.g. arduino-bridge-blink --> |
+
+## Test Environment
+
+| Field | Value |
+|-------|-------|
+| **Host OS** | <!-- Ubuntu 24.04 / macOS 15 --> |
+| **Cross-toolchain** | <!-- e.g. aarch64-linux-gnu-gcc 13.x --> |
+| **Firmware / OS on board** | <!-- e.g. Arduino Uno Q Debian image v1.0 --> |
+
+## Results
+
+<!-- Describe what worked, what didn't, and any unexpected behaviour. -->
+
+| Test | Result | Notes |
+|------|--------|-------|
+| Build (cross-compile) | pass / fail | |
+| Deploy | pass / fail | |
+| Runtime — basic function | pass / fail | |
+| Runtime — specific feature | pass / fail | |
+
+## Arduino Uno Q Specific (if applicable)
+
+<!-- Fill in the open validation TODOs from docs/boards/arduino_uno_q.md -->
+
+| Item | Verified? | Correct Value / Notes |
+|------|-----------|----------------------|
+| `gpio/write` method name | | |
+| `gpio/read` method name | | |
+| `gpio/mode` method name | | |
+| `Bridge.run()` / `loop()` / `process()` | | |
+| MsgPack-RPC framing (4-byte length prefix) | | |
+
+## Full Output / Logs
+
+```
+paste relevant output here
+```
+
+## Conclusion
+
+<!-- Summary: does this board/example work as documented? What should change in docs or code? -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,33 @@
+# Code of Conduct
+
+## Our Pledge
+
+We are committed to making participation in this project a welcoming experience for everyone, regardless of background or experience level.
+
+## Our Standards
+
+**Positive behaviour includes:**
+- Being respectful and constructive in discussions
+- Welcoming contributors of all experience levels
+- Accepting feedback graciously
+- Focusing on what is best for the project and community
+
+**Unacceptable behaviour includes:**
+- Harassment, insults, or personal attacks
+- Trolling or deliberately disruptive behaviour
+- Publishing others' private information without permission
+
+## Enforcement
+
+Instances of unacceptable behaviour may be reported by opening a private security advisory or contacting the maintainer directly. All reports will be reviewed and addressed.
+
+## AI-Assisted Contributions
+
+AI-assisted contributions are welcome. We treat them as first-class citizens — what matters
+is that the contributor understands the change, has reviewed the output, and stands behind it.
+Please disclose AI assistance in the PR description. See `CONTRIBUTING.md` for the full
+checklist.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -522,9 +522,20 @@ controller. Added recommendation to use lgpio instead.
 
 ## AI-Assisted Contributions
 
-Commits generated or assisted by AI tools (e.g., Claude Code) must be disclosed in the PR
-description. Remove AI co-author trailers (`Co-Authored-By: Claude ...`) from commits before
-submitting to upstream.
+AI-assisted PRs are welcome — built with Claude, Codex, Copilot, or any other tool.
+We treat them as first-class contributions. We just ask for transparency so reviewers
+know what to look for.
+
+**Checklist for AI-assisted PRs:**
+
+- [ ] Disclose AI assistance in the PR description (tool used, scope)
+- [ ] Confirm you have reviewed and understand the generated code
+- [ ] Note the degree of testing (untested / lightly tested / fully tested)
+- [ ] Remove AI co-author trailers (`Co-Authored-By: Claude ...`) from commits before submitting
+- [ ] If hardware was involved, note whether it was tested on real hardware or build-only
+
+AI-generated code is held to the same review standard as human-authored code.
+The contributor is responsible for the correctness of what they submit.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,13 +23,13 @@ If you discover a security vulnerability in platform-linux_arm, please report it
 
 | Version | Supported |
 | ------- | --------- |
-| 1.7.x   | Yes       |
-| 1.6.x   | Yes       |
-| < 1.6   | No        |
+| 1.9.x   | Yes       |
+| 1.8.x   | Yes       |
+| < 1.8   | No        |
 
 ## Security Features
 
-See [SECURITY.md](SECURITY.md) for security documentation, including:
+See [docs/SECURITY.md](docs/SECURITY.md) for security documentation, including:
 
 - Command injection protection
 - Timeout protection against DoS attacks
@@ -45,7 +45,7 @@ See [SECURITY.md](SECURITY.md) for security documentation, including:
 - Added security documentation
 - Enhanced SSH security features
 
-For detailed security audit history, see [SECURITY.md](SECURITY.md#security-audit-history).
+For detailed security audit history, see [docs/SECURITY.md](docs/SECURITY.md#security-audit-history).
 
 ## Security Best Practices
 
@@ -57,7 +57,7 @@ When using this platform:
 - Use dedicated SSH keys for different environments
 - Never commit credentials or private keys to version control
 
-For complete security guidelines, see [SECURITY.md](SECURITY.md).
+For complete security guidelines, see [docs/SECURITY.md](docs/SECURITY.md).
 
 ## License
 


### PR DESCRIPTION
## Summary

- Rename `SECURITY_POLICY.md` → `SECURITY.md` (GitHub convention — enables Security Policy tab and fixes broken links from README.md and docs/)
- Update supported versions to 1.8.x / 1.9.x
- Add `.github/ISSUE_TEMPLATE/`: Bug Report, Feature Request, Hardware Validation (with Arduino Uno Q validation TODOs), `config.yml`
- Add `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1 + AI contributions welcome statement)
- Expand `CONTRIBUTING.md` AI-assisted contributions section from terse compliance note to openclaw-style welcoming checklist

## Test plan

- [ ] Verify Security Policy tab appears at https://github.com/sfo2001/platform-linux_arm/security
- [ ] Verify "New Issue" shows template menu (Bug Report, Feature Request, Hardware Validation)
- [ ] Verify README.md `SECURITY.md` links resolve
- [ ] Verify `CODE_OF_CONDUCT.md` appears in GitHub community health checklist

🤖 Generated with [Claude Code](https://claude.ai/claude-code)