### PR TITLE
docs(examples): add README.md to arduino-bridge-blink and arduino-uno-q-hello

### DIFF
--- a/examples/arduino-bridge-blink/README.md
+++ b/examples/arduino-bridge-blink/README.md
@@ -1,0 +1,144 @@
+# Arduino Bridge Blink
+
+This example demonstrates the `arduino-bridge` framework: a Linux C++ program on the
+Arduino Uno Q's application processor (AArch64) controlling the MCU's GPIO via
+MsgPack-RPC over a Unix socket.
+
+> **Community Testing Notice:** The RPC method names (`gpio/mode`, `gpio/write`,
+> `aio/read`) and parameter formats have not been validated on physical hardware.
+> Please open an issue with your test results.
+
+## What It Does
+
+1. Connects to the `arduino-router` daemon running on the board
+2. Sets MCU pin D13 (built-in LED) to OUTPUT mode via `gpio/mode`
+3. Blinks D13 five times (1 second on, 1 second off) via `gpio/write`
+4. Reads analog pin A0 via `aio/read`
+5. Disconnects
+
+The Linux host process calls MCU methods defined in the companion Arduino sketch
+(`mcu_companion/ArduinoUnoQ_MraaCompanion.ino`). The two sides communicate over
+`/var/run/arduino-router.sock`.
+
+## Prerequisites
+
+### Build-time (on development machine)
+
+1. **MRAA cross-compiled for AArch64:**
+   ```bash
+   CROSS_PREFIX=aarch64-linux-gnu- ./scripts/setup-mraa-cross.sh
+   ```
+   See [CONTRIBUTING.md](../../CONTRIBUTING.md#5-set-up-mraa-for-cross-compilation-arduino-bridge-optional) for full setup.
+
+2. **msgpack-cxx headers** (on the development machine):
+   ```bash
+   # Linux
+   sudo apt install libmsgpack-cxx-dev
+
+   # macOS
+   brew install msgpack-cxx
+   ```
+
+### Runtime (on the Arduino Uno Q board)
+
+1. **MCU companion sketch flashed** to the STM32U585:
+   Flash `mcu_companion/ArduinoUnoQ_MraaCompanion.ino` using the Arduino IDE
+   or Arduino CLI targeting the Arduino Uno Q MCU.
+
+2. **`arduino-router` daemon running:**
+   ```bash
+   systemctl status arduino-router
+   # If not running:
+   systemctl start arduino-router
+   ```
+
+## Building
+
+```bash
+pio run -e arduino_uno_q
+
+# Clean build artifacts
+pio run --target clean
+```
+
+The compiled binary is at `.pio/build/arduino_uno_q/program`.
+
+## Running
+
+Transfer the binary to the board and run it:
+
+```bash
+# Copy to board
+scp .pio/build/arduino_uno_q/program user@uno-q-host:~/bridge_blink
+
+# Run on board
+ssh user@uno-q-host ./bridge_blink
+```
+
+Expected output:
+
+```
+arduino-bridge-blink: Arduino Uno Q example
+Connecting to arduino-router...
+Connected.
+
+gpio/mode pin=13 mode=OUTPUT: OK
+Blinking D13 five times...
+  gpio/write pin=13 value=1 (LED ON)
+  gpio/write pin=13 value=0 (LED OFF)
+  ...
+
+aio/read pin=A0 (pin=0): value=512
+
+Done.
+```
+
+## Upload via PlatformIO
+
+Uncomment the upload section in `platformio.ini` to deploy directly:
+
+```ini
+upload_protocol = scp
+upload_port = user@uno-q-host
+upload_path = ~/bridge_blink
+upload_run_after = true
+```
+
+Then run:
+
+```bash
+pio run -e arduino_uno_q --target upload
+```
+
+## Architecture
+
+```
+Development machine (x86_64 / macOS / Windows)
+    └── pio run → cross-compile AArch64 binary
+
+Arduino Uno Q (AArch64 Linux)
+    ├── bridge_blink  ←→  /var/run/arduino-router.sock  ←→  arduino-router
+    │   (this program)                                        (daemon)
+    │                                                              │
+    │                                                         STM32U585 MCU
+    │                                                              │
+    │                                                         D13 LED / A0 pin
+    └── (GPIO controlled via MsgPack-RPC, not directly)
+```
+
+## Troubleshooting
+
+**`Failed to connect to arduino-router socket`**
+- Check the daemon: `systemctl status arduino-router`
+- Check the socket: `ls -la /var/run/arduino-router.sock`
+- Override socket path: `ARDUINO_ROUTER_SOCKET=/path/to/sock ./bridge_blink`
+
+**`MRAA not found` during build**
+- Run `CROSS_PREFIX=aarch64-linux-gnu- ./scripts/setup-mraa-cross.sh` from the repo root
+
+## References
+
+- [Arduino Uno Q board documentation](../../docs/boards/arduino_uno_q.md)
+- [arduino-bridge framework](../../builder/frameworks/arduino_bridge.py)
+- [Companion MCU sketch](mcu_companion/)
+- [arduino-uno-q-hello](../arduino-uno-q-hello/) — bare-metal example without GPIO

--- a/examples/arduino-uno-q-hello/README.md
+++ b/examples/arduino-uno-q-hello/README.md
@@ -1,0 +1,96 @@
+# Arduino Uno Q — Hello World (Bare-Metal AArch64)
+
+This example demonstrates a bare-metal C application targeting the Arduino Uno Q's
+application processor: a Qualcomm QRB2210 (4x Cortex-A53, AArch64). No GPIO framework
+is used — this is a pure Linux userspace program.
+
+> **Community Testing Notice:** This board port has not been validated on physical
+> hardware. Please open an issue with your test results.
+
+## About the Arduino Uno Q
+
+The Arduino Uno Q is an Arduino form-factor board powered by a QRB2210 SoC running
+Debian Linux AArch64. It has two sides:
+
+- **Application processor (AArch64)** — runs Linux, this is where your PlatformIO code runs
+- **MCU (STM32U585)** — handles real-time GPIO; reached via the `arduino-bridge` framework
+
+This hello-world example targets the application processor only. For GPIO access, see
+the [`arduino-bridge-blink`](../arduino-bridge-blink/) example.
+
+## Hardware Requirements
+
+- Arduino Uno Q
+- SSH access to the board (Ethernet or Wi-Fi configured)
+
+## System Requirements
+
+Cross-compiler for AArch64 on your development machine:
+
+```bash
+# Linux (Ubuntu/Debian)
+sudo apt install gcc-aarch64-linux-gnu
+
+# macOS (Homebrew)
+brew tap messense/macos-cross-toolchains
+brew install aarch64-unknown-linux-gnu
+```
+
+## Building
+
+```bash
+# Build for Arduino Uno Q
+pio run -e arduino_uno_q
+
+# Clean build artifacts
+pio run --target clean
+```
+
+The compiled binary is at `.pio/build/arduino_uno_q/program`.
+
+## Running
+
+Transfer the binary to the board and run it over SSH:
+
+```bash
+# Copy to board
+scp .pio/build/arduino_uno_q/program user@uno-q-host:~/hello_uno_q
+
+# Run on board
+ssh user@uno-q-host ./hello_uno_q
+```
+
+Expected output:
+
+```
+Hello from Arduino Uno Q!
+Board: Arduino Uno Q (QRB2210 AArch64)
+MCU: Qualcomm QRB2210 (4x Cortex-A53 @ 2.0 GHz)
+OS:  Debian Linux (AArch64)
+
+Note: GPIO requires the arduino-router daemon and
+      the arduino-bridge framework (Phase 2).
+      See docs/boards/arduino_uno_q.md for details.
+```
+
+## Upload via PlatformIO
+
+Uncomment and configure the upload section in `platformio.ini` to deploy directly:
+
+```ini
+upload_protocol = scp
+upload_port = user@uno-q-host
+upload_path = /tmp/hello_uno_q
+upload_run_after = true
+```
+
+Then run:
+
+```bash
+pio run -e arduino_uno_q --target upload
+```
+
+## References
+
+- [Arduino Uno Q board documentation](../../docs/boards/arduino_uno_q.md)
+- [arduino-bridge-blink](../arduino-bridge-blink/) — GPIO example using the MCU


### PR DESCRIPTION
## Summary

Closes #110. Completes per-example README coverage across all 21 examples.

- **arduino-uno-q-hello/README.md** — AArch64 cross-compiler prerequisites, build/run/upload instructions, expected output, SSH deploy workflow, relationship to arduino-bridge-blink
- **arduino-bridge-blink/README.md** — Full prerequisites (MRAA cross-compilation, msgpack-cxx headers, MCU companion sketch, arduino-router daemon), architecture diagram, expected output, troubleshooting section, community testing notice

19 of 21 examples already had READMEs. These two were the only gaps.

## Review Notes

All 21 READMEs were cross-checked against `platformio.ini` env names, source code GPIO pins and expected output, board JSON definitions, and relative file links. One broken anchor link was caught and fixed before opening this PR (`arduino-bridge-blink`: CONTRIBUTING.md heading anchor `#5-set-up-mraa-...`).

## Test plan

- [ ] Verify rendered README looks correct on GitHub for both new examples
- [ ] Click the CONTRIBUTING.md anchor link in arduino-bridge-blink README — should jump to section 5
- [ ] Confirm `pio run -e arduino_uno_q` matches the build command documented in both READMEs

## AI Assistance

Generated with Claude Code (Sonnet 4.6). READMEs reviewed and verified against source code, platformio.ini, and board definitions before committing. Anchor link fix applied after automated review caught a broken fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)