### PR TITLE
feat(arduino-bridge): add setup-mraa PlatformIO target (closes #111)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,10 @@ CROSS_PREFIX=aarch64-linux-gnu- INSTALL_DIR=$HOME/.local/aarch64-linux-gnu \
 
 **MRAA** (required for `arduino-bridge` framework):
 ```bash
+# Recommended — auto-detects toolchain, from any arduino-bridge project directory:
+pio run --target setup-mraa
+
+# Or manually:
 CROSS_PREFIX=aarch64-linux-gnu- ./scripts/setup-mraa-cross.sh           # AArch64
 ```
 
@@ -265,8 +269,8 @@ Follows [Conventional Commits](https://www.conventionalcommits.org/).
 ## Common Gotchas
 
 **MRAA not found during arduino-bridge build**
-Run `CROSS_PREFIX=aarch64-linux-gnu- ./scripts/setup-mraa-cross.sh` from the repo root
-before building any `arduino-bridge` example.
+Run `pio run --target setup-mraa` from the example directory (auto-detects toolchain).
+Or manually: `CROSS_PREFIX=aarch64-linux-gnu- ./scripts/setup-mraa-cross.sh` from the repo root.
 
 **Wrong architecture library picked**
 `get_target_arch()` checks `board_build.arch` from `platformio.ini` before the board

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `examples/arduino-uno-q-hello` — bare-metal AArch64 hello-world example for Arduino Uno Q
 - `examples/arduino-bridge-blink` — LED blink example using arduino-bridge with MCU companion sketch
 - `scripts/setup-mraa-cross.sh` — MRAA cross-compilation script for AArch64
+- `setup-mraa` PlatformIO custom target in `arduino-bridge` framework — run `pio run --target setup-mraa` from any arduino-bridge project to cross-compile and install MRAA without invoking the script manually
 
 ### Fixed
 - `actions/setup-python` was incorrectly pinned to `actions/upload-artifact` SHA

--- a/builder/frameworks/arduino_bridge.py
+++ b/builder/frameworks/arduino_bridge.py
@@ -41,11 +41,16 @@ https://github.com/eclipse/mraa
 https://github.com/arduino/arduino-router
 """
 
+import os
+import shutil
+import subprocess
 import sys
 from os.path import expanduser, isfile, join
 
-from SCons.Script import DefaultEnvironment
-from utils import get_target_arch
+from SCons.Script import COMMAND_LINE_TARGETS, DefaultEnvironment
+from utils import get_target_arch, get_toolchain_prefix
+
+from platform_constants import Architecture
 
 env = DefaultEnvironment()
 
@@ -90,10 +95,96 @@ def _find_msgpack(home):
     return None
 
 
+# --------------------------------------------------------------------------
+# setup-mraa custom target
+#
+# Registered BEFORE any env.Exit() calls so it is always available, even
+# when MRAA is not yet installed. Developers can run:
+#
+#   pio run --target setup-mraa
+#
+# from any arduino-bridge example directory to cross-compile and install
+# MRAA without manually invoking scripts/setup-mraa-cross.sh.
+# --------------------------------------------------------------------------
+
+
+def _mraa_setup_action(target, source, env):
+    """Cross-compile and install MRAA for AArch64 via setup-mraa-cross.sh.
+
+    Returns non-zero to signal failure to SCons — do NOT call env.Exit() here.
+    SCons action functions communicate failure via return code, not env.Exit().
+    """
+    if sys.platform == "win32":
+        sys.stderr.write(
+            "ERROR: setup-mraa is not supported on Windows.\n"
+            "Use WSL2 (Ubuntu) to cross-compile MRAA for AArch64.\n"
+        )
+        return 1
+
+    if not shutil.which("cmake"):
+        sys.stderr.write(
+            "ERROR: cmake not found. Install it first:\n"
+            "  Linux:  sudo apt install cmake\n"
+            "  macOS:  brew install cmake\n"
+        )
+        return 1
+
+    prefix = get_toolchain_prefix(Architecture.AARCH64)
+    install_dir = join(expanduser("~"), ".local", "aarch64-linux-gnu")
+    platform_dir = env.PioPlatform().get_dir()
+    script = join(platform_dir, "scripts", "setup-mraa-cross.sh")
+
+    print("\nSetting up MRAA for AArch64 cross-compilation...")
+    print(f"  CROSS_PREFIX: {prefix}")
+    print(f"  INSTALL_DIR:  {install_dir}")
+    print(f"  Script:       {script}")
+    print()
+
+    # Pass only required variables — do not forward CI secrets or tokens.
+    _passthrough = ("PATH", "HOME", "TMPDIR", "TEMP", "LANG", "LC_ALL")
+    env_vars = {k: os.environ[k] for k in _passthrough if k in os.environ}
+    env_vars["CROSS_PREFIX"] = prefix
+    env_vars["INSTALL_DIR"] = install_dir
+
+    try:
+        result = subprocess.run(
+            ["bash", script], env=env_vars, cwd=platform_dir, timeout=600
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write(
+            "\nMRAA setup timed out after 10 minutes.\n"
+            "Check your network connection and cmake installation, then retry.\n"
+        )
+        return 1
+
+    if result.returncode == 0:
+        print("\nMRAA setup complete. You can now build arduino-bridge projects.")
+    else:
+        sys.stderr.write(
+            f"\nMRAA setup failed (exit code {result.returncode}).\n"
+            "Check the output above for details.\n"
+        )
+    return result.returncode
+
+
+env.AddCustomTarget(
+    "setup-mraa",
+    None,
+    [_mraa_setup_action],
+    title="Setup MRAA",
+    description="Cross-compile and install MRAA for AArch64 (arduino-bridge framework)",
+)
+
+# When setup-mraa is the only requested target, skip framework configuration —
+# MRAA may not be installed yet, so the checks below would fail. Exact-match
+# is intentional: mixing setup-mraa with build targets (e.g. "setup-mraa upload")
+# is not a supported workflow and should fall through to the normal MRAA check.
+_SETUP_ONLY = list(COMMAND_LINE_TARGETS) == ["setup-mraa"]
+
 # Arduino Uno Q is AArch64-only. The arduino-bridge framework is not supported
 # on 32-bit ARM targets.
 target_arch = get_target_arch(env)
-if target_arch != "aarch64":
+if not _SETUP_ONLY and target_arch != "aarch64":
     sys.stderr.write(
         "ERROR: arduino-bridge framework is only supported on AArch64 targets.\n"
         "The Arduino Uno Q uses a Qualcomm QRB2210 (AArch64). "
@@ -101,57 +192,61 @@ if target_arch != "aarch64":
     )
     env.Exit(1)
 
-home = expanduser("~")
+if not _SETUP_ONLY:
+    home = expanduser("~")
 
-mraa_include, mraa_lib = _find_mraa(home)
+    mraa_include, mraa_lib = _find_mraa(home)
 
-if not mraa_include or not mraa_lib:
-    sys.stderr.write(
-        "ERROR: MRAA library not found for AArch64!\n"
-        "\n"
-        "The arduino-bridge framework requires MRAA cross-compiled for AArch64.\n"
-        "\n"
-        "To install:\n"
-        "  sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu cmake\n"
-        "  CROSS_PREFIX=aarch64-linux-gnu- ./scripts/setup-mraa-cross.sh\n"
-        "\n"
-        "  (macOS) brew tap messense/macos-cross-toolchains\n"
-        "  (macOS) brew install aarch64-unknown-linux-gnu cmake\n"
-        "  (macOS) CROSS_PREFIX=aarch64-unknown-linux-gnu- "
-        "INSTALL_DIR=$HOME/.local/aarch64-linux-gnu ./scripts/setup-mraa-cross.sh\n"
-        "\n"
-        "See docs/boards/arduino_uno_q.md for complete instructions.\n"
+    if not mraa_include or not mraa_lib:
+        sys.stderr.write(
+            "ERROR: MRAA library not found for AArch64!\n"
+            "\n"
+            "The arduino-bridge framework requires MRAA cross-compiled for AArch64.\n"
+            "\n"
+            "Quick fix — run the setup target from your project directory:\n"
+            "  pio run --target setup-mraa\n"
+            "\n"
+            "Or manually:\n"
+            "  sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu cmake\n"
+            "  CROSS_PREFIX=aarch64-linux-gnu- ./scripts/setup-mraa-cross.sh\n"
+            "\n"
+            "  (macOS) brew tap messense/macos-cross-toolchains\n"
+            "  (macOS) brew install aarch64-unknown-linux-gnu cmake\n"
+            "  (macOS) CROSS_PREFIX=aarch64-unknown-linux-gnu- "
+            "INSTALL_DIR=$HOME/.local/aarch64-linux-gnu ./scripts/setup-mraa-cross.sh\n"
+            "\n"
+            "See docs/boards/arduino_uno_q.md for complete instructions.\n"
+        )
+        env.Exit(1)
+
+    # Find msgpack-cxx headers (header-only, installed via libmsgpack-cxx-dev)
+    # Required for ArduinoBridgeImpl.cpp serialization
+    msgpack_include = _find_msgpack(home)
+
+    if not msgpack_include:
+        sys.stderr.write(
+            "ERROR: msgpack-cxx headers not found!\n"
+            "\n"
+            "Install with:\n"
+            "  sudo apt install libmsgpack-cxx-dev  (Ubuntu/Debian)\n"
+            "  brew install msgpack-cxx           (macOS)\n"
+            "\n"
+        )
+        env.Exit(1)
+
+    framework_dir = join(env.PioPlatform().get_dir(), "framework-arduino-bridge")
+
+    env.Replace(CPPFLAGS=["-O2", "-Wall", "-std=c++17", "-pipe", "-fPIC"])
+
+    # Suppress Boost dependency in msgpack-cxx headers (set by arduino_bridge.py via CPPDEFINES).
+    # Listed here so the file compiles correctly in IDEs without the PlatformIO env.
+    env.Append(CPPDEFINES=["MSGPACK_NO_BOOST"])
+
+    env.Append(
+        CPPPATH=[mraa_include, msgpack_include, framework_dir],
+        LIBPATH=[mraa_lib],
+        LIBS=["mraa"],
     )
-    env.Exit(1)
 
-# Find msgpack-cxx headers (header-only, installed via libmsgpack-cxx-dev)
-# Required for ArduinoBridgeImpl.cpp serialization
-msgpack_include = _find_msgpack(home)
-
-if not msgpack_include:
-    sys.stderr.write(
-        "ERROR: msgpack-cxx headers not found!\n"
-        "\n"
-        "Install with:\n"
-        "  sudo apt install libmsgpack-cxx-dev  (Ubuntu/Debian)\n"
-        "  brew install msgpack-cxx           (macOS)\n"
-        "\n"
-    )
-    env.Exit(1)
-
-framework_dir = join(env.PioPlatform().get_dir(), "framework-arduino-bridge")
-
-env.Replace(CPPFLAGS=["-O2", "-Wall", "-std=c++17", "-pipe", "-fPIC"])
-
-# Suppress Boost dependency in msgpack-cxx headers (set by arduino_bridge.py via CPPDEFINES).
-# Listed here so the file compiles correctly in IDEs without the PlatformIO env.
-env.Append(CPPDEFINES=["MSGPACK_NO_BOOST"])
-
-env.Append(
-    CPPPATH=[mraa_include, msgpack_include, framework_dir],
-    LIBPATH=[mraa_lib],
-    LIBS=["mraa"],
-)
-
-# Build the ArduinoBridge C++ MsgPack-RPC client library
-env.BuildSources(join("$BUILD_DIR", "FrameworkArduinoBridge"), framework_dir)
+    # Build the ArduinoBridge C++ MsgPack-RPC client library
+    env.BuildSources(join("$BUILD_DIR", "FrameworkArduinoBridge"), framework_dir)

--- a/docs/boards/arduino_uno_q.md
+++ b/docs/boards/arduino_uno_q.md
@@ -198,7 +198,19 @@ int main() {
 
 ### Setup: cross-compile MRAA
 
-The arduino-bridge framework requires MRAA to be cross-compiled for AArch64:
+The arduino-bridge framework requires MRAA to be cross-compiled for AArch64.
+
+**Option A — PlatformIO target (recommended):**
+
+```bash
+# From any arduino-bridge example directory
+pio run --target setup-mraa
+```
+
+Auto-detects the AArch64 toolchain prefix and installs to
+`~/.local/aarch64-linux-gnu/`.
+
+**Option B — Manual:**
 
 ```bash
 # Ubuntu/Debian cross-compile host

--- a/examples/arduino-bridge-blink/README.md
+++ b/examples/arduino-bridge-blink/README.md
@@ -24,7 +24,11 @@ The Linux host process calls MCU methods defined in the companion Arduino sketch
 
 ### Build-time (on development machine)
 
-1. **MRAA cross-compiled for AArch64:**
+1. **MRAA cross-compiled for AArch64** — use the PlatformIO target (recommended):
+   ```bash
+   pio run --target setup-mraa
+   ```
+   Or manually:
    ```bash
    CROSS_PREFIX=aarch64-linux-gnu- ./scripts/setup-mraa-cross.sh
    ```
@@ -134,7 +138,8 @@ Arduino Uno Q (AArch64 Linux)
 - Override socket path: `ARDUINO_ROUTER_SOCKET=/path/to/sock ./bridge_blink`
 
 **`MRAA not found` during build**
-- Run `CROSS_PREFIX=aarch64-linux-gnu- ./scripts/setup-mraa-cross.sh` from the repo root
+- Run `pio run --target setup-mraa` from this directory (recommended)
+- Or manually: `CROSS_PREFIX=aarch64-linux-gnu- ./scripts/setup-mraa-cross.sh` from the repo root
 
 ## References
 

--- a/tests/test_arduino_bridge_builder.py
+++ b/tests/test_arduino_bridge_builder.py
@@ -17,6 +17,7 @@
 
 import importlib.util
 import os
+import subprocess
 import types
 from unittest.mock import patch
 
@@ -32,20 +33,34 @@ _FRAMEWORK_PATH = os.path.join(
 )
 
 
-def _load_helpers():
-    """Load _find_mraa and _find_msgpack without triggering SCons execution."""
+def _make_scons_stub(arch="aarch64", command_line_targets=None):
+    """Build SCons + utils stubs needed by arduino_bridge.py."""
 
     class _FakeEnv:
         def Exit(self, code):
             raise SystemExit(code)
 
+        def AddCustomTarget(self, *args, **kwargs):
+            pass
+
     scons_stub = types.ModuleType("SCons")
     scons_script_stub = types.ModuleType("SCons.Script")
     scons_script_stub.DefaultEnvironment = _FakeEnv
+    scons_script_stub.COMMAND_LINE_TARGETS = (
+        command_line_targets if command_line_targets is not None else []
+    )
     scons_stub.Script = scons_script_stub
 
     utils_stub = types.ModuleType("utils")
-    utils_stub.get_target_arch = lambda env: "aarch64"
+    utils_stub.get_target_arch = lambda env: arch
+    utils_stub.get_toolchain_prefix = lambda arch: "aarch64-linux-gnu-"
+
+    return scons_stub, scons_script_stub, utils_stub
+
+
+def _load_helpers():
+    """Load _find_mraa and _find_msgpack without triggering SCons execution."""
+    scons_stub, scons_script_stub, utils_stub = _make_scons_stub()
 
     with patch.dict(
         "sys.modules",
@@ -69,20 +84,11 @@ def _load_helpers():
         return mod
 
 
-def _load_module_with_arch(arch):
+def _load_module_with_arch(arch, command_line_targets=None):
     """Reload the module with a specific target architecture, capturing SystemExit."""
-
-    class _FakeEnv:
-        def Exit(self, code):
-            raise SystemExit(code)
-
-    scons_stub = types.ModuleType("SCons")
-    scons_script_stub = types.ModuleType("SCons.Script")
-    scons_script_stub.DefaultEnvironment = _FakeEnv
-    scons_stub.Script = scons_script_stub
-
-    utils_stub = types.ModuleType("utils")
-    utils_stub.get_target_arch = lambda env: arch
+    scons_stub, scons_script_stub, utils_stub = _make_scons_stub(
+        arch=arch, command_line_targets=command_line_targets
+    )
 
     with patch.dict(
         "sys.modules",
@@ -255,3 +261,172 @@ class TestModuleGuards:
         assert exc.code == 1
         captured = capsys.readouterr()
         assert "mraa" in captured.err.lower()
+
+    def test_mraa_not_found_error_mentions_setup_target(self, capsys):
+        """MRAA missing error message mentions 'pio run --target setup-mraa'."""
+        with patch("os.path.isfile", return_value=False):
+            _, exc = _load_module_with_arch("aarch64")
+        assert exc is not None
+        captured = capsys.readouterr()
+        assert "setup-mraa" in captured.err
+
+
+class TestSetupMraaTarget:
+    """Test the setup-mraa custom target and _SETUP_ONLY bypass."""
+
+    def test_setup_only_bypasses_arch_guard(self):
+        """With COMMAND_LINE_TARGETS=['setup-mraa'], non-aarch64 arch does not exit."""
+        _, exc = _load_module_with_arch("armv7", command_line_targets=["setup-mraa"])
+        assert exc is None, "setup-mraa target should bypass the arch guard"
+
+    def test_setup_only_bypasses_mraa_check(self):
+        """With COMMAND_LINE_TARGETS=['setup-mraa'], missing MRAA does not exit."""
+        with patch("os.path.isfile", return_value=False):
+            _, exc = _load_module_with_arch(
+                "aarch64", command_line_targets=["setup-mraa"]
+            )
+        assert exc is None, "setup-mraa target should bypass the MRAA check"
+
+    def test_setup_only_flag_set_when_target_matches(self):
+        """_SETUP_ONLY is True when COMMAND_LINE_TARGETS is exactly ['setup-mraa']."""
+        with patch("os.path.isfile", return_value=False):
+            mod, exc = _load_module_with_arch(
+                "aarch64", command_line_targets=["setup-mraa"]
+            )
+        assert exc is None
+        assert mod is not None
+        assert mod._SETUP_ONLY is True
+
+    def test_setup_only_false_for_normal_build(self):
+        """Normal build without MRAA exits; _SETUP_ONLY bypass does not apply."""
+        with patch("os.path.isfile", return_value=False):
+            _, exc = _load_module_with_arch("aarch64", command_line_targets=[])
+        # MRAA not found → module exits; the point is that setup-mraa bypass did NOT fire
+        assert (
+            exc is not None
+        ), "Expected SystemExit when MRAA missing and no setup target"
+        assert exc.code == 1
+
+    def test_setup_only_false_when_mixed_targets(self):
+        """_SETUP_ONLY is False when setup-mraa is combined with other targets."""
+        with patch("os.path.isfile", return_value=False):
+            _, exc = _load_module_with_arch(
+                "aarch64", command_line_targets=["setup-mraa", "upload"]
+            )
+        # Mixed targets should not bypass — MRAA check triggers exit
+        assert exc is not None, "Mixed targets should not bypass MRAA check"
+
+    def test_setup_only_bypasses_msgpack_check(self):
+        """With COMMAND_LINE_TARGETS=['setup-mraa'], missing msgpack does not exit."""
+        # Make MRAA headers appear to exist, but msgpack absent
+        mraa_hpp = os.path.join(
+            os.path.expanduser("~"),
+            ".local",
+            "aarch64-linux-gnu",
+            "include",
+            "mraa",
+            "mraa.hpp",
+        )
+        mraa_lib = os.path.join(
+            os.path.expanduser("~"),
+            ".local",
+            "aarch64-linux-gnu",
+            "lib",
+            "libmraa.so",
+        )
+        present = {mraa_hpp, mraa_lib}
+        with patch("os.path.isfile", side_effect=lambda p: p in present):
+            _, exc = _load_module_with_arch(
+                "aarch64", command_line_targets=["setup-mraa"]
+            )
+        assert exc is None, "setup-mraa target should bypass the msgpack check"
+
+
+class TestMraaSetupAction:
+    """Unit tests for _mraa_setup_action — all five execution branches."""
+
+    def _make_mock_env(self, platform_dir):
+        """Build a minimal mock PlatformIO env for _mraa_setup_action."""
+
+        class _FakePlatform:
+            def get_dir(self):
+                return str(platform_dir)
+
+        class _FakeEnv:
+            def PioPlatform(self):
+                return _FakePlatform()
+
+        return _FakeEnv()
+
+    def _get_action(self):
+        """Load _mraa_setup_action from a setup-mraa module load."""
+        with patch("os.path.isfile", return_value=False):
+            mod, _ = _load_module_with_arch(
+                "aarch64", command_line_targets=["setup-mraa"]
+            )
+        assert mod is not None, "Module must load under setup-mraa target"
+        return mod._mraa_setup_action
+
+    def test_windows_returns_error(self, capsys, tmp_path):
+        """Returns 1 and prints error on Windows (sys.platform == 'win32')."""
+        action = self._get_action()
+        env = self._make_mock_env(tmp_path)
+        with patch("sys.platform", "win32"):
+            result = action([], [], env)
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "windows" in captured.err.lower() or "wsl" in captured.err.lower()
+
+    def test_cmake_missing_returns_error(self, capsys, tmp_path):
+        """Returns 1 and prints error when cmake is not found in PATH."""
+        action = self._get_action()
+        env = self._make_mock_env(tmp_path)
+        with patch("sys.platform", "linux"), patch("shutil.which", return_value=None):
+            result = action([], [], env)
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "cmake" in captured.err.lower()
+
+    def test_subprocess_success_returns_zero(self, capsys, tmp_path):
+        """Returns 0 and prints success message when subprocess exits cleanly."""
+        action = self._get_action()
+        env = self._make_mock_env(tmp_path)
+        mock_result = type("R", (), {"returncode": 0})()
+        with (
+            patch("sys.platform", "linux"),
+            patch("shutil.which", return_value="/usr/bin/cmake"),
+            patch("subprocess.run", return_value=mock_result),
+        ):
+            result = action([], [], env)
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "complete" in captured.out.lower()
+
+    def test_subprocess_failure_returns_nonzero(self, capsys, tmp_path):
+        """Returns non-zero exit code and prints failure message on script error."""
+        action = self._get_action()
+        env = self._make_mock_env(tmp_path)
+        mock_result = type("R", (), {"returncode": 2})()
+        with (
+            patch("sys.platform", "linux"),
+            patch("shutil.which", return_value="/usr/bin/cmake"),
+            patch("subprocess.run", return_value=mock_result),
+        ):
+            result = action([], [], env)
+        assert result == 2
+        captured = capsys.readouterr()
+        assert "failed" in captured.err.lower()
+
+    def test_subprocess_timeout_returns_error(self, capsys, tmp_path):
+        """Returns 1 and prints timeout message when subprocess times out."""
+        action = self._get_action()
+        env = self._make_mock_env(tmp_path)
+        with (
+            patch("sys.platform", "linux"),
+            patch("shutil.which", return_value="/usr/bin/cmake"),
+            patch("subprocess.run", side_effect=subprocess.TimeoutExpired("bash", 600)),
+        ):
+            result = action([], [], env)
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "timed out" in captured.err.lower()


### PR DESCRIPTION
## Description

Adds a `setup-mraa` PlatformIO custom target to the `arduino-bridge` framework, letting developers cross-compile and install MRAA for AArch64 with a single command instead of invoking the shell script manually.

```bash
# From any arduino-bridge example directory
pio run --target setup-mraa
```

Also includes fixes for all findings from the pre-PR audit (`fix` commit).

## Type of Change

- [x] [FEATURE] New feature (non-breaking change which adds functionality)
- [x] [TEST] Test update
- [x] [DOCS] Documentation update

## Related Issues

Closes #111

## What Changed

### Feature (`feat` commit — `b991195`)
- `builder/frameworks/arduino_bridge.py` — registers `setup-mraa` custom target via `env.AddCustomTarget`; `_mraa_setup_action` cross-compiles MRAA via `scripts/setup-mraa-cross.sh` with Windows guard, cmake check, 10-minute timeout
- `_SETUP_ONLY` bypass flag skips arch/MRAA/msgpack guards when only `setup-mraa` is requested (MRAA may not yet be installed)
- Error messages for MRAA/msgpack now mention `pio run --target setup-mraa` as the quick fix
- `tests/test_arduino_bridge_builder.py` — 10 new tests in `TestSetupMraaTarget` and `TestMraaSetupAction` covering all five execution branches
- `docs/boards/arduino_uno_q.md` — Option A (pio target) / Option B (manual) setup structure
- `examples/arduino-bridge-blink/README.md`, `AGENTS.md`, `CHANGELOG.md` — updated MRAA setup instructions

### Audit Fixes (`fix` commit — `7005759`)
- **Security**: replaced `os.environ.copy()` with explicit allowlist (`PATH`, `HOME`, `TMPDIR`, `TEMP`, `LANG`, `LC_ALL`) — avoids forwarding CI secrets to subprocess
- **Docs**: added SCons return-code contract comment to `_mraa_setup_action` (returns non-zero, not `env.Exit()` — intentional divergence)
- **Code**: moved `_find_mraa`/`_find_msgpack` probes inside `if not _SETUP_ONLY:` guard (skips unnecessary I/O on setup-only runs)
- **Tests**: fixed `TestMraaSetupAction` docstring ("four" → "five" branches), added `test_setup_only_bypasses_msgpack_check`
- **Docs**: README.md troubleshooting and AGENTS.md Framework Libraries section now lead with `pio run --target setup-mraa`

## Checklist

### Testing

- [x] I have tested my changes locally
- [x] All CI/CD checks pass

### Code Quality

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly
- [x] I have updated the README.md if needed
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) specification

### Framework Changes (if applicable)

- [x] I have tested the framework with examples
- [x] I have updated framework documentation

## Test Results

### Build Test Results

```
============================= test session starts ==============================
collected 24 items

TestSetupMraaTarget::test_setup_only_bypasses_arch_guard        PASSED
TestSetupMraaTarget::test_setup_only_bypasses_mraa_check        PASSED
TestSetupMraaTarget::test_setup_only_flag_set_when_target_matches PASSED
TestSetupMraaTarget::test_setup_only_false_for_normal_build     PASSED
TestSetupMraaTarget::test_setup_only_false_when_mixed_targets   PASSED
TestSetupMraaTarget::test_setup_only_bypasses_msgpack_check     PASSED
TestMraaSetupAction::test_windows_returns_error                 PASSED
TestMraaSetupAction::test_cmake_missing_returns_error           PASSED
TestMraaSetupAction::test_subprocess_success_returns_zero       PASSED
TestMraaSetupAction::test_subprocess_failure_returns_nonzero    PASSED
TestMraaSetupAction::test_subprocess_timeout_returns_error      PASSED
... (all 24 tests) ...

24 passed in 2.49s
arduino_bridge.py coverage: 88.12%
```

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**