### PR TITLE
feat(platform): add dev-loop composite build/upload/monitor target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ docs/_build/
 !examples/**/.vscode/
 .idea/
 
+# Claude Code local session data (settings, locks — not for version control)
+.claude/
+
 # OS artifacts
 .DS_Store
 Thumbs.db

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,6 +89,38 @@ repos:
         args: ['--convention=google', '--add-ignore=D100,D104,D105,D107,D212']
         files: ^(builder/|platform\.py)
 
+  # Type checking — mirrors CI exactly (same 4-file scope as tests.yml lint job)
+  - repo: local
+    hooks:
+      - id: mypy
+        name: Type check with mypy
+        entry: mypy
+        args:
+          - platform_constants.py
+          - platform.py
+          - platform_config.py
+          - platform_test_uploader.py
+        language: system
+        pass_filenames: false
+        files: \.py$
+
+  # Pylint — mirrors CI exactly (same *.py scope as tests.yml lint job)
+  - repo: local
+    hooks:
+      - id: pylint
+        name: Lint with pylint
+        entry: pylint
+        args:
+          - --rcfile=.pylintrc
+          - platform.py
+          - platform_config.py
+          - platform_constants.py
+          - platform_test_uploader.py
+          - ssh_utils.py
+        language: system
+        pass_filenames: false
+        files: \.py$
+
 # Configuration
 ci:
   autofix_commit_msg: 'style: auto-fix pre-commit hooks'

--- a/.pylintrc
+++ b/.pylintrc
@@ -34,4 +34,9 @@ disable =
     C0413,
 
     # Singleton initializer uses 'global' statement — valid pattern, one instance.
-    W0603
+    W0603,
+
+    # on_dev_loop orchestrates build→upload→monitor as a single state machine;
+    # splitting into sub-functions would require passing mutable result dict as
+    # a parameter across every branch, harming readability more than it helps.
+    R0915

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,76 @@ pio pkg install --global --platform symlink://.
 pio run -e raspberrypi_4b_upload --target upload
 ```
 
+### Agent-Driven Dev Loop
+
+The `dev-loop` target chains build → upload → monitor in one command
+with structured JSON output. Designed for AI agent iteration loops.
+
+```bash
+# Run complete dev loop
+pio run --target dev-loop
+
+# With specific environment
+pio run -e raspberrypi_4b_upload --target dev-loop
+```
+
+**Configuration** in `platformio.ini`:
+
+```ini
+[env:raspberrypi_4b_upload]
+platform = linux_arm
+board = raspberrypi_4b
+upload_protocol = scp
+upload_port = pi@raspberrypi.local:/home/pi/myapp
+dev_loop_monitor_timeout = 30   ; seconds (default: 30)
+upload_run_command = ./myapp --flag  ; optional: custom remote command
+```
+
+> **Security:** `upload_run_command` is passed verbatim through the remote shell.
+> Shell metacharacters (`;`, `&&`, `|`, backticks) in its value will execute arbitrary
+> commands on the remote host. Only set values you authored — never derive this option
+> from untrusted external input.
+
+**Structured JSON output** — extract between `--- DEV_LOOP_RESULT ---` delimiters:
+
+```json
+{
+  "schema_version": "1",
+  "phases": {
+    "build": { "status": "pass" },
+    "upload": { "status": "pass", "error": null },
+    "monitor": {
+      "status": "pass",
+      "exit_code": 0,
+      "timed_out": false,
+      "timeout_seconds": 30,
+      "output": "Hello from ARM!\n"
+    }
+  },
+  "overall_status": "pass",
+  "failure_phase": null,
+  "elapsed_seconds": 18.4,
+  "timestamp_iso": "2026-04-05T14:23:11+02:00"
+}
+```
+
+The JSON is also written to `.pio/build/<env>/dev-loop-result.json`.
+
+**Agent parsing guidance:**
+
+- Extract JSON between the two `--- DEV_LOOP_RESULT ---` lines
+- Check `overall_status` first: `"pass"` or `"fail"`
+- If `"fail"`, check `failure_phase` (`"upload"` or `"monitor"`)
+- `phases.monitor.status` has three possible values: `"pass"`, `"fail"`, `"timeout"`
+- `monitor.timed_out == true` means program ran for the full timeout; `status` will be `"timeout"` (not `"fail"`)
+- If upload phase fails, `phases.monitor` is omitted (never ran)
+
+**Error handling:**
+
+- On SSH failure: `failure_phase` is `"upload"`, check `phases.upload.error`
+- Do not retry faster than every 5 seconds (avoids SSH connection storms)
+- The dev loop is idempotent — binary is overwritten on each upload
+
 ---
 
 ## Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,6 +290,48 @@ The JSON is also written to `.pio/build/<env>/dev-loop-result.json`.
 
 ---
 
+## Branch Workflow
+
+`develop` and `main` are **protected branches**. Direct pushes are rejected.
+CI must be green before any branch can merge into `develop`.
+
+### Rules (no exceptions)
+
+1. **Never commit directly to `develop` or `main`** — even for a one-liner.
+2. **Never use `--no-verify`** — hook failures are signals, not noise. If a hook
+   fails, fix the root cause. Bypassing it hides toolchain drift that will break CI.
+3. **Verify toolchain parity before starting any work:**
+
+   ```bash
+   pre-commit run --all-files
+   ```
+
+   If this fails on a clean checkout, fix the toolchain mismatch first as a
+   separate commit before making any product changes.
+4. **Branch naming:** `fix/NNN-short-description`, `feat/NNN-short-description`,
+   `chore/description`, `style/description` — where NNN is the issue number if one exists.
+5. **CI must pass on the branch** before merging into `develop`.
+
+### Workflow
+
+```bash
+git checkout develop && git pull
+git checkout -b fix/119-pwm-init-sentinel    # branch off develop
+pre-commit run --all-files                   # verify toolchain is clean
+# ... make changes, commit (hooks must pass) ...
+git push -u origin fix/119-pwm-init-sentinel
+# wait for CI green, then merge
+```
+
+### Why this matters
+
+A broken toolchain on `develop` (e.g. mismatched black line-length between
+pre-commit and CI) is invisible until CI runs. Working through a branch means CI
+catches the problem on the branch before develop is touched. A dirty develop
+history is the cost of skipping this step.
+
+---
+
 ## Testing
 
 ### Python Unit Tests
@@ -338,10 +380,12 @@ Follows [Conventional Commits](https://www.conventionalcommits.org/).
 | `ci` | GitHub Actions workflows |
 | `config` | Platform config file support |
 | `debug` | GDB/SSH remote debugging |
+| `dev-loop` | Dev-loop composite build/upload/monitor target |
 | `docs` | Documentation |
 | `examples` | Example projects |
 | `frameworks` | Framework support (generic) |
 | `lgpio` | lgpio-specific changes |
+| `pwm-hal` | PWM HAL (`framework-lgpio/pwm-hal.c`) changes |
 | `libgpiod` | libgpiod-specific changes |
 | `monitor` | SSH serial monitor |
 | `onboarding` | First-run welcome and setup |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `dev-loop` composite target: `pio run --target dev-loop` chains build → upload → monitor with structured JSON output for AI agent integration (closes #112)
+
 ## [2.0.0] - 2026-04-16
 
 ### Breaking Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -543,6 +543,7 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/) specifica
 - `onboarding`: First-run welcome and setup
 - `pigpio`: pigpio-specific changes
 - `platform`: Platform core changes
+- `pwm-hal`: PWM HAL (`framework-lgpio/pwm-hal.c`) changes
 - `scripts`: Build and setup scripts
 - `security`: Security policy and hardening (host key verification, injection prevention)
 - `test`: Remote test execution

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -535,6 +535,7 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/) specifica
 - `ci`: CI/CD configuration
 - `config`: Platform configuration file support
 - `debug`: GDB/SSH remote debugging
+- `dev-loop`: Dev-loop composite build/upload/monitor target and result schema
 - `docs`: Documentation
 - `frameworks`: Framework support (lgpio, libgpiod, pigpio, wiringpi)
 - `lgpio`: lgpio-specific changes

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -57,6 +57,11 @@ Run all tests:
 pytest
 ```
 
+> **Important:** Always use `pytest` (the console script), not `python -m pytest`.
+> Running `python -m pytest` from the project root causes Python to add the current
+> directory to `sys.path`, making `platform.py` shadow the stdlib `platform` module
+> before pytest even reads `pytest.ini`. The `pytest` command avoids this.
+
 Run with verbose output:
 
 ```bash
@@ -68,6 +73,11 @@ Run specific test file:
 ```bash
 pytest tests/test_platform.py -v
 ```
+
+> **Note:** `tests/test_dev_loop.py` uses `importlib.util.spec_from_file_location` to load
+> `platform.py` directly instead of a standard import. This is required because `platform` is
+> a Python stdlib module name — a normal `import platform` would shadow the project file.
+> This pattern is specific to `test_dev_loop.py`; other test files use `conftest.py` fixtures.
 
 Run specific test class:
 
@@ -450,6 +460,7 @@ platform-linux_arm/
 │   │   └── pwm-hal-sysfs-stub.h   # Stub control interface
 │   ├── conftest.py             # Shared pytest fixtures
 │   ├── test_platform.py        # Platform tests
+│   ├── test_dev_loop.py        # Dev-loop feature tests
 │   ├── test_ssh_utils.py       # SSH utilities tests
 │   ├── test_platform_config.py # Config tests
 │   └── test_pwm_hal.c          # PWM HAL C unit tests (CMake/ctest)

--- a/README.md
+++ b/README.md
@@ -230,6 +230,16 @@ pio run --target upload
 
 Requires `upload_protocol` configuration - see [docs/UPLOAD.md](docs/UPLOAD.md).
 
+### Build, Upload, and Monitor (Dev Loop)
+
+```bash
+pio run --target dev-loop
+```
+
+Runs a composite build → upload → monitor workflow and emits structured JSON output
+for AI agent integration. See [AGENTS.md](AGENTS.md) for the full result
+schema reference.
+
 ### Run Tests on Hardware
 
 ```bash

--- a/builder/main.py
+++ b/builder/main.py
@@ -251,6 +251,54 @@ env.AddCustomTarget(
 )
 
 #
+# Target: Dev loop (build + upload + monitor with structured output)
+#
+
+
+def _dev_loop_handler(target, source, env) -> int:
+    """
+    Handle dev-loop target: build → upload → monitor cycle.
+
+    Runs a complete development iteration with structured JSON output
+    for AI agent consumption. Build is handled by SCons dependency
+    resolution; this handler orchestrates upload and monitor phases.
+
+    Args:
+        target: Build target.
+        source: List of source files (binary path).
+        env: SCons environment object.
+
+    Returns:
+        int: Exit code (0 = all phases passed, non-zero = failure).
+
+    See Also:
+        - Linux_armPlatform.on_dev_loop: Platform dev-loop implementation
+    """
+    platform = env.PioPlatform()
+    if hasattr(platform, "on_dev_loop"):
+        return platform.on_dev_loop(target, source, env)
+
+    from platform_constants import UIConstants
+
+    separator = UIConstants.SEPARATOR_CHAR * UIConstants.SEPARATOR_WIDTH
+    print("\n" + separator)
+    print("DEV LOOP NOT SUPPORTED")
+    print(separator)
+    print("\nThis platform version does not support the dev-loop target.")
+    print(separator + "\n")
+    return 1
+
+
+env.AddCustomTarget(
+    name="dev-loop",
+    dependencies=target_bin,
+    actions=_dev_loop_handler,
+    title="Dev Loop",
+    description="Build, upload, and monitor in one step (agent-friendly)",
+    always_build=True,
+)
+
+#
 # Default targets
 #
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,10 +1,14 @@
 # Configuration File Support
 
-The Linux ARM platform supports configuration files to set global defaults, reducing duplication across projects and simplifying project configuration.
+The Linux ARM platform supports configuration files to set global
+defaults, reducing duplication across projects and simplifying
+project configuration.
 
 ## Overview
 
-Instead of repeating configuration in every project's `platformio.ini`, you can define defaults in `.platform-linux_arm.ini` files that are automatically loaded by the platform.
+Instead of repeating configuration in every project's `platformio.ini`,
+you can define defaults in `.platform-linux_arm.ini` files that are
+automatically loaded by the platform.
 
 ### Benefits
 
@@ -31,6 +35,7 @@ Configuration values are resolved in the following order (highest to lowest prio
 4. **Hard-coded defaults**: Platform's built-in default values
 
 **Example**: If `upload_timeout` is set in all locations:
+
 - `platformio.ini`: `upload_timeout = 600` ← **Used**
 - Project-local config: `upload_timeout = 400`
 - Global config: `upload_timeout = 300`
@@ -88,6 +93,19 @@ test_username = pi
 | `test_upload_timeout` | integer | `300` | Test binary upload timeout (seconds) |
 | `test_timeout` | integer | `600` | Test execution timeout (seconds) |
 
+### Dev Loop Settings
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `dev_loop_monitor_timeout` | integer | `30` | Timeout for remote program monitoring during dev-loop (seconds) |
+
+> **Tip:** For production environments, set
+> `upload_strict_host_check = true` to enable SSH host key
+> verification during dev-loop uploads.
+
+See [`AGENTS.md`](../AGENTS.md) for the full dev-loop usage guide, JSON schema
+reference, and agent integration patterns.
+
 ## Usage Examples
 
 ### Example 1: Global Configuration
@@ -103,6 +121,7 @@ nano ~/.platformio/.platform-linux_arm.ini
 ```
 
 **~/.platformio/.platform-linux_arm.ini:**
+
 ```ini
 [defaults]
 # My Raspberry Pi uses a custom SSH port
@@ -118,6 +137,7 @@ upload_user = pi
 ```
 
 **Project platformio.ini** (minimal configuration):
+
 ```ini
 [env:raspberrypi_4b]
 platform = linux_arm
@@ -132,6 +152,7 @@ upload_port = raspberrypi.local:/home/pi/myapp
 Use different settings for a specific project:
 
 **~/.platformio/.platform-linux_arm.ini** (global defaults):
+
 ```ini
 [defaults]
 upload_user = pi
@@ -139,6 +160,7 @@ upload_timeout = 300
 ```
 
 **.platform-linux_arm.ini** (project-local, overrides global):
+
 ```ini
 [defaults]
 # This project uses a different user
@@ -149,6 +171,7 @@ upload_timeout = 600
 ```
 
 **platformio.ini** (can still override everything):
+
 ```ini
 [env:raspberrypi_4b]
 platform = linux_arm
@@ -164,6 +187,7 @@ upload_timeout = 900
 Set up SSH key authentication globally:
 
 **~/.platformio/.platform-linux_arm.ini:**
+
 ```ini
 [defaults]
 upload_ssh_key = ~/.ssh/raspberry_pi_key
@@ -178,6 +202,7 @@ Now all projects automatically use SSH key authentication without needing to spe
 For continuous integration environments with slower connections:
 
 **.platform-linux_arm.ini** (in project root, committed to git):
+
 ```ini
 [defaults]
 # CI/CD environments may need longer timeouts
@@ -195,6 +220,7 @@ test_path = /tmp/ci_test
 Manage different device configurations using project-local configs:
 
 **Project A** (Raspberry Pi 4):
+
 ```bash
 # .platform-linux_arm.ini
 [defaults]
@@ -204,6 +230,7 @@ upload_path = /home/pi/app_a
 ```
 
 **Project B** (Orange Pi):
+
 ```bash
 # .platform-linux_arm.ini
 [defaults]
@@ -217,16 +244,19 @@ upload_path = /opt/app_b
 ### Global Configuration
 
 1. Create the PlatformIO configuration directory:
+
    ```bash
    mkdir -p ~/.platformio
    ```
 
 2. Copy the example configuration:
+
    ```bash
    cp .platform-linux_arm.ini.example ~/.platformio/.platform-linux_arm.ini
    ```
 
 3. Edit the configuration:
+
    ```bash
    nano ~/.platformio/.platform-linux_arm.ini
    ```
@@ -234,16 +264,19 @@ upload_path = /opt/app_b
 ### Project-Local Configuration
 
 1. Copy the example to your project root:
+
    ```bash
    cp .platform-linux_arm.ini.example .platform-linux_arm.ini
    ```
 
 2. Edit as needed:
+
    ```bash
    nano .platform-linux_arm.ini
    ```
 
 3. *(Optional)* Add to version control if you want to share with team:
+
    ```bash
    git add .platform-linux_arm.ini
    git commit -m "Add platform configuration"
@@ -259,6 +292,7 @@ python3 platform_config.py
 ```
 
 This will display:
+
 - Loaded configuration files
 - All active configuration values
 - Search paths
@@ -268,6 +302,7 @@ This will display:
 If you have existing projects with repeated configuration, you can easily migrate:
 
 **Before** (duplicated in every project):
+
 ```ini
 # Project 1: platformio.ini
 [env]
@@ -283,6 +318,7 @@ upload_ssh_port = 22
 ```
 
 **After** (DRY with global config):
+
 ```ini
 # ~/.platformio/.platform-linux_arm.ini (once)
 [defaults]

--- a/platform.json
+++ b/platform.json
@@ -136,6 +136,10 @@
     "debug_strict_host_check": {
       "type": "boolean",
       "description": "Enable SSH strict host key checking for GDB debug sessions (default: false)"
+    },
+    "dev_loop_monitor_timeout": {
+      "type": "integer",
+      "description": "Timeout in seconds for remote program monitoring during dev-loop (default: 30)"
     }
   },
   "debug": {

--- a/platform.py
+++ b/platform.py
@@ -55,14 +55,17 @@ Author: PlatformIO
 License: Apache 2.0
 """
 
+import datetime
 import json
 import os
 import posixpath
+import re
 import shlex
 import shutil
 import subprocess
 import sys
-from typing import Any, Dict, List
+import time
+from typing import Any, Dict, List, Tuple
 
 from platformio import exception
 from platformio.public import PlatformBase, get_systype
@@ -858,7 +861,7 @@ class Linux_armPlatform(PlatformBase):
         if _PLATFORM_DIR not in sys.path:
             sys.path.insert(0, _PLATFORM_DIR)
         from platform_constants import Timeouts, UIConstants
-        from ssh_utils import SSHCommandBuilder, SSHConnectionConfig
+        from ssh_utils import SSHConnectionConfig
 
         strict_host_check = parse_bool_option(
             env.GetProjectOption(
@@ -879,35 +882,17 @@ class Linux_armPlatform(PlatformBase):
         except (ValueError, FileNotFoundError) as e:
             raise exception.PlatformioException(str(e))
 
-        # Get custom run command or use default
-        run_command = env.GetProjectOption("upload_run_command", None)
-        if run_command:
-            # SECURITY: upload_run_command is treated as trusted user input from platformio.ini.
-            # Arbitrary shell metacharacters are intentionally permitted. See docs/SECURITY.md.
-            remote_command = run_command
-        else:
-            # Determine the actual executable path
-            # Rule: If remote_path ends with '/', it's a directory - append program name
-            #       Otherwise, it's the full file path - use as-is
-            if source and remote_path.endswith("/"):
-                program_name = os.path.basename(str(source[0]))
-                executable_path = posixpath.join(remote_path, program_name)
-            else:
-                executable_path = remote_path
-
-            # For simple path execution, quote the path to prevent injection
-            remote_command = shlex.quote(executable_path)
-
-        # Build SSH command using shared builder
-        builder = SSHCommandBuilder(config)
-        cmd = builder.build_ssh_command(remote_command)
+        # Build SSH command using shared helper
+        cmd, display_path = Linux_armPlatform._build_ssh_execute_cmd(
+            config, env, remote_path, source
+        )
 
         separator = UIConstants.SEPARATOR_CHAR * UIConstants.SEPARATOR_WIDTH
         print("\n" + separator)
         print("RUNNING REMOTE PROGRAM")
         print(separator)
         print(f"Target: {user}@{host}")
-        print(f"Command: {run_command if run_command else executable_path}")
+        print(f"Command: {display_path}")
         print(separator + "\n")
 
         # Execute remote command with timeout protection (interactive - shows output directly)
@@ -1020,6 +1005,346 @@ class Linux_armPlatform(PlatformBase):
 
         # Run the remote command and stream output
         return self._run_remote_command(user, host, ssh_port, ssh_key, path, env, source)
+
+    def on_dev_loop(self, target, source, env) -> int:
+        """
+        Execute build → upload → monitor dev loop with structured JSON output.
+
+        Build is handled by SCons dependency resolution (target_bin).
+        This method orchestrates upload and monitor phases, collecting
+        results into a structured JSON summary for AI agent consumption.
+
+        Args:
+            target: Build target.
+            source: List of source files (binary path).
+            env: PlatformIO environment object.
+
+        Returns:
+            int: 0 if all phases passed, 1 if any phase failed.
+
+        Note:
+            JSON output is printed to stdout between delimiter lines
+            and also written to BUILD_DIR/dev-loop-result.json.
+            Configure monitor timeout via dev_loop_monitor_timeout
+            in platformio.ini (default: 30 seconds).
+
+            A monitor timeout (monitor_timed_out=True) is treated as
+            overall_status='pass', not 'fail'. This is intentional for
+            long-running daemon workloads expected to run indefinitely.
+            Use phases.monitor.status == 'timeout' to distinguish this case
+            from a clean exit.
+        """
+        # Lazy import to avoid breaking platform loading
+        if _PLATFORM_DIR not in sys.path:
+            sys.path.insert(0, _PLATFORM_DIR)
+        from platform_constants import DevLoopConstants, UIConstants
+
+        start_time = time.monotonic()
+
+        separator = UIConstants.SEPARATOR_CHAR * UIConstants.SEPARATOR_WIDTH
+        print("\n" + separator)
+        print("DEV LOOP: BUILD → UPLOAD → MONITOR")
+        print(separator + "\n")
+
+        result: Dict[str, Any] = {
+            "schema_version": DevLoopConstants.SCHEMA_VERSION,
+            "phases": {
+                "build": {"status": "pass"},
+            },
+            "overall_status": "pass",
+            "failure_phase": None,
+        }
+
+        # Warn if upload_run_after=true — the program will execute twice
+        # (once during upload, once during monitor). This is intentional but
+        # users may not expect it. Unlike on_monitor(), _run_dev_loop_monitor
+        # always executes the program regardless of upload_run_after.
+        if parse_bool_option(env.GetProjectOption("upload_run_after", False)):
+            print(f"\n{separator}")
+            print("DEV LOOP: WARNING")
+            print(separator)
+            print(
+                "\nupload_run_after = true is set in platformio.ini.\n"
+                "The program will run TWICE: once during the upload phase\n"
+                "and once during the monitor phase.\n"
+                "To avoid double execution, remove upload_run_after = true."
+            )
+            print(separator + "\n")
+
+        print(separator)
+        print("DEV LOOP: UPLOAD PHASE")
+        print(separator + "\n")
+
+        upload_error = None
+        try:
+            upload_rc = self.on_upload(target, source, env)
+            if upload_rc != 0:
+                upload_error = f"Upload returned non-zero exit code: {upload_rc}"
+        except (exception.PlatformioException, OSError, subprocess.TimeoutExpired) as e:
+            # subprocess.TimeoutExpired is caught here as defence-in-depth: if a custom
+            # upload protocol raises it unwrapped, on_dev_loop still emits a structured
+            # JSON result (failure_phase=upload) rather than propagating an unhandled
+            # exception. The built-in protocols (SCP, rsync, SSH) already wrap this as
+            # PlatformioException, so this clause is a fallback for future/custom protocols.
+            upload_rc = 1
+            upload_error = Linux_armPlatform._scrub_error_message(str(e))
+
+        if upload_error:
+            result["phases"]["upload"] = {
+                "status": "fail",
+                "error": upload_error,
+            }
+            result["overall_status"] = "fail"
+            result["failure_phase"] = "upload"
+            elapsed = time.monotonic() - start_time
+            result["elapsed_seconds"] = round(elapsed, 2)
+            result["timestamp_iso"] = self._iso_timestamp()
+            self._emit_dev_loop_result(result, env)
+            return 1
+
+        result["phases"]["upload"] = {"status": "pass", "error": None}
+
+        print("\n" + separator)
+        print("DEV LOOP: MONITOR PHASE")
+        print(separator + "\n")
+
+        _timeout_raw = env.GetProjectOption(
+            "dev_loop_monitor_timeout",
+            self._get_config_default(
+                "dev_loop_monitor_timeout",
+                DevLoopConstants.MONITOR_TIMEOUT,
+            ),
+        )
+        try:
+            monitor_timeout = int(_timeout_raw)
+        except ValueError as exc:
+            raise exception.PlatformioException(
+                f"dev_loop_monitor_timeout must be an integer, got {_timeout_raw!r}"
+            ) from exc
+        if monitor_timeout <= 0:
+            raise exception.PlatformioException(
+                f"dev_loop_monitor_timeout must be a positive integer, got {monitor_timeout}"
+            )
+
+        monitor_output, monitor_exit_code, monitor_timed_out = self._run_dev_loop_monitor(
+            env, source, monitor_timeout
+        )
+
+        if monitor_timed_out:
+            monitor_status = "timeout"
+        elif monitor_exit_code != 0:
+            monitor_status = "fail"
+        else:
+            monitor_status = "pass"
+
+        result["phases"]["monitor"] = {
+            "status": monitor_status,
+            "exit_code": monitor_exit_code,
+            "timed_out": monitor_timed_out,
+            "timeout_seconds": monitor_timeout,
+            "output": monitor_output,
+        }
+
+        if monitor_status == "fail":
+            result["overall_status"] = "fail"
+            result["failure_phase"] = "monitor"
+
+        elapsed = time.monotonic() - start_time
+        result["elapsed_seconds"] = round(elapsed, 2)
+        result["timestamp_iso"] = self._iso_timestamp()
+
+        self._emit_dev_loop_result(result, env)
+        return 0 if result["overall_status"] == "pass" else 1
+
+    def _run_dev_loop_monitor(self, env, source, timeout: int) -> Tuple[str, int, bool]:
+        """
+        Run remote program with timeout and capture output.
+
+        Unlike on_monitor() which streams output interactively, this method
+        captures all output for inclusion in the structured JSON result.
+
+        Args:
+            env: PlatformIO environment object.
+            source: List of source files (binary path).
+            timeout: Maximum execution time in seconds.
+
+        Returns:
+            Tuple of (output: str, exit_code: int, timed_out: bool).
+        """
+        # Lazy import to avoid breaking platform loading
+        if _PLATFORM_DIR not in sys.path:
+            sys.path.insert(0, _PLATFORM_DIR)
+        from platform_constants import DevLoopConstants, SSHDefaults
+        from ssh_utils import SSHConnectionConfig
+
+        upload_port = env.GetProjectOption("upload_port", None)
+        if not upload_port:
+            raise exception.PlatformioException(
+                "upload_port is not configured. Set upload_port in platformio.ini."
+            )
+
+        user, host, remote_path = self._parse_upload_port(upload_port, env)
+
+        ssh_port = env.GetProjectOption(
+            "upload_ssh_port",
+            self._get_config_default("upload_ssh_port", SSHDefaults.PORT),
+        )
+        ssh_key = env.GetProjectOption(
+            "upload_ssh_key",
+            self._get_config_default("upload_ssh_key", None),
+        )
+        strict_host_check = parse_bool_option(
+            env.GetProjectOption(
+                "upload_strict_host_check",
+                self._get_config_default("upload_strict_host_check", False),
+            )
+        )
+
+        try:
+            config = SSHConnectionConfig(
+                user=user,
+                host=host,
+                port=ssh_port,
+                key=ssh_key,
+                strict_host_check=strict_host_check,
+            )
+        except (ValueError, FileNotFoundError) as e:
+            return (
+                f"SSH config error: {Linux_armPlatform._scrub_error_message(str(e))}",
+                1,
+                False,
+            )
+
+        cmd, display_path = Linux_armPlatform._build_ssh_execute_cmd(
+            config, env, remote_path, source
+        )
+
+        print(f"Running: {user}@{host} -> {display_path}")
+        print(f"Timeout: {timeout}s\n")
+
+        stdout_bytes = b""
+        timed_out = False
+        exit_code = -1
+        try:
+            # stderr is merged into stdout so agents receive all output in one stream.
+            process = subprocess.Popen(  # pylint: disable=consider-using-with
+                cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+            )
+            stdout_bytes, _ = process.communicate(timeout=timeout)
+            exit_code = process.returncode
+        except subprocess.TimeoutExpired:
+            process.kill()
+            try:
+                stdout_bytes, _ = process.communicate(timeout=10)
+            except subprocess.TimeoutExpired:
+                stdout_bytes = b""
+            exit_code = process.returncode if process.returncode is not None else -1
+            timed_out = True
+
+        stdout = stdout_bytes.decode("utf-8", errors="replace") if stdout_bytes else ""
+        output = re.sub(r"[^\x09\x0a\x0d\x20-\x7e]", "", stdout)
+
+        if len(output) > DevLoopConstants.MAX_OUTPUT_BYTES:
+            output = output[: DevLoopConstants.MAX_OUTPUT_BYTES] + "\n[truncated]"
+
+        return (output, exit_code, timed_out)
+
+    @staticmethod
+    def _build_ssh_execute_cmd(
+        config,
+        env,
+        remote_path: str,
+        source=None,
+    ) -> Tuple[List[str], str]:
+        """Build SSH command list and display path for remote execution.
+
+        Shared by _run_remote_command (interactive) and _run_dev_loop_monitor
+        (capture mode) to avoid duplicating upload_run_command handling and
+        executable path resolution.
+
+        Args:
+            config: SSH connection configuration.
+            env: PlatformIO environment (read upload_run_command option).
+            remote_path: Remote path to executable or directory.
+            source: Optional source file list (for extracting program name).
+
+        Returns:
+            Tuple of (cmd: list[str], display_path: str).
+        """
+        # Lazy import to avoid breaking platform loading
+        from ssh_utils import SSHCommandBuilder
+
+        run_command = env.GetProjectOption("upload_run_command", None)
+        if run_command:
+            # SECURITY: upload_run_command is treated as trusted user input from platformio.ini.
+            # Arbitrary shell metacharacters are intentionally permitted. See docs/SECURITY.md.
+            remote_command = run_command
+            display_path = run_command
+        else:
+            if source and remote_path.endswith("/"):
+                program_name = os.path.basename(str(source[0]).replace("\\", "/"))
+                executable_path = posixpath.join(remote_path, program_name)
+            else:
+                executable_path = remote_path
+            remote_command = shlex.quote(executable_path)
+            display_path = executable_path
+
+        builder = SSHCommandBuilder(config)
+        cmd = builder.build_ssh_command(remote_command)
+        return cmd, display_path
+
+    @staticmethod
+    def _scrub_error_message(msg: str) -> str:
+        """Replace absolute paths with a placeholder before persisting error messages.
+
+        Prevents SSH key paths, usernames, and connection details from leaking
+        into the persisted dev-loop-result.json file.
+        """
+        return re.sub(
+            r"([A-Za-z]:\\\S+|\\\\[^\s]+|/\S+|\S+@\S+|\b\S*\.ssh\S*|\bkeys/\S+)",
+            "[redacted]",
+            msg,
+        )
+
+    @staticmethod
+    def _iso_timestamp() -> str:
+        """Return current time as ISO 8601 string with timezone."""
+        return datetime.datetime.now(datetime.timezone.utc).astimezone().isoformat()
+
+    def _emit_dev_loop_result(self, result: Dict, env) -> None:
+        """
+        Emit dev-loop result as delimited JSON to stdout and write to file.
+
+        Args:
+            result: Result dictionary matching the dev-loop JSON schema.
+            env: PlatformIO environment object (for BUILD_DIR path).
+        """
+        # Lazy import to avoid breaking platform loading
+        if _PLATFORM_DIR not in sys.path:
+            sys.path.insert(0, _PLATFORM_DIR)
+        from platform_constants import DevLoopConstants, UIConstants
+
+        json_output = json.dumps(result, indent=2)
+
+        # Print delimited JSON to stdout
+        separator = UIConstants.SEPARATOR_CHAR * UIConstants.SEPARATOR_WIDTH
+        print("\n" + separator)
+        print(DevLoopConstants.OUTPUT_DELIMITER)
+        print(json_output)
+        print(DevLoopConstants.OUTPUT_DELIMITER)
+        print(separator + "\n")
+
+        # Write to file in build directory
+        try:
+            build_dir = env.subst("$BUILD_DIR")
+            os.makedirs(build_dir, exist_ok=True)
+            result_path = os.path.join(build_dir, DevLoopConstants.RESULT_FILENAME)
+            with open(result_path, "w", encoding="utf-8") as f:
+                f.write(json_output)
+            print(f"Result written to: {result_path}")
+        except OSError as e:
+            scrubbed = Linux_armPlatform._scrub_error_message(str(e))
+            print(f"Warning: Could not write result file: {scrubbed}")
 
     def _determine_gdb_executable(self, target_arch: str) -> str:
         """

--- a/platform_constants.py
+++ b/platform_constants.py
@@ -94,6 +94,25 @@ class Timeouts:
     CHMOD: Final[int] = 30
 
 
+class DevLoopConstants:
+    """Constants for the dev-loop composite target."""
+
+    # Default timeout for monitoring remote program (seconds)
+    MONITOR_TIMEOUT: Final[int] = 30
+
+    # Delimiter for structured JSON output (agents extract JSON between these)
+    OUTPUT_DELIMITER: Final[str] = "--- DEV_LOOP_RESULT ---"
+
+    # Result filename written to build directory
+    RESULT_FILENAME: Final[str] = "dev-loop-result.json"
+
+    # JSON schema version
+    SCHEMA_VERSION: Final[str] = "1"
+
+    # Maximum bytes of monitor output to include in JSON result
+    MAX_OUTPUT_BYTES: Final[int] = 64 * 1024
+
+
 class TestConstants:
     """Constants for test execution and output parsing."""
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,6 +11,12 @@ testpaths = tests
 
 # Output options
 addopts =
+    # Use importlib import mode to prevent platform.py from shadowing stdlib
+    # platform module. Works when using 'pytest' directly from the project root.
+    # Note: does NOT help when using 'python -m pytest' from the project root —
+    # pytest crashes before reading ini in that case. Use 'pytest' (the console
+    # script) or run from a parent directory to avoid stdlib shadowing.
+    --import-mode=importlib
     # Verbose output
     -v
     # Show local variables in tracebacks
@@ -21,12 +27,9 @@ addopts =
     --strict-markers
     # Show warnings
     -W default
-    # Coverage options (when pytest-cov is installed)
-    --cov=.
-    --cov-report=term-missing
-    --cov-report=html
-    # Exclude venv and build directories from coverage
-    --cov-config=.coveragerc
+    # Coverage is NOT enabled by default to keep local runs fast.
+    # CI enables coverage explicitly: pytest tests/ --cov=. --cov-report=xml
+    # For local coverage: pytest --cov=. --cov-report=term-missing
 
 # Markers for categorizing tests
 markers =

--- a/tests/test_dev_loop.py
+++ b/tests/test_dev_loop.py
@@ -1,0 +1,941 @@
+#!/usr/bin/env python3
+# Copyright 2014-present PlatformIO <contact@platformio.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for dev-loop feature (on_dev_loop, _run_dev_loop_monitor)."""
+
+import datetime
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from unittest.mock import Mock, mock_open, patch
+
+import pytest
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from platformio import exception  # noqa: E402
+
+# Import platform.py module explicitly to avoid conflict with stdlib platform module
+_platform_path = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "platform.py"
+)
+spec = importlib.util.spec_from_file_location("platform_module", _platform_path)
+platform_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(platform_module)
+
+sys.modules["platform_module"] = platform_module
+
+
+@pytest.fixture
+def mock_platform_manifest():
+    """Create a mock platform manifest."""
+    return "test_manifest"
+
+
+@pytest.fixture
+def make_platform(mock_platform_manifest):
+    """Factory fixture that creates a Linux_armPlatform with mocks.
+
+    Shadows conftest.make_platform to support per-test config_overrides via **kwargs.
+    """
+
+    def _make(**config_overrides):
+        with patch("platform_module.PlatformBase.__init__", return_value=None), patch(
+            "platform_module.get_platform_config", return_value=Mock()
+        ), patch("platform_module.Linux_armPlatform._show_welcome_if_needed"):
+            from platform_module import Linux_armPlatform
+
+            platform = Linux_armPlatform(mock_platform_manifest)
+            platform._config = config_overrides
+            return platform
+
+    return _make
+
+
+def _make_env(options=None):
+    """Create a mock env with GetProjectOption support."""
+    defaults = {
+        "upload_port": "pi@raspberrypi.local:/home/pi/app",
+        "upload_protocol": "scp",
+        "upload_ssh_port": 22,
+        "upload_ssh_key": None,
+        "upload_strict_host_check": False,
+        "upload_run_command": None,
+        "dev_loop_monitor_timeout": 30,
+        "upload_run_after": False,
+    }
+    if options:
+        defaults.update(options)
+
+    env = Mock()
+    env.GetProjectOption = Mock(side_effect=lambda key, default=None: defaults.get(key, default))
+    env.subst = Mock(return_value=os.path.join(tempfile.gettempdir(), "build_dir"))
+    env.get = Mock(return_value=None)
+    return env
+
+
+class TestOnDevLoopUploadRunAfter:
+    """Test on_dev_loop behavior when upload_run_after=true."""
+
+    @patch("builtins.open", mock_open())
+    @patch("os.makedirs")
+    @patch("platform_module.Linux_armPlatform._run_dev_loop_monitor")
+    @patch("platform_module.Linux_armPlatform.on_upload")
+    @patch("builtins.print")
+    def test_upload_run_after_true_prints_warning(
+        self, mock_print, mock_upload, mock_monitor, _mock_makedirs, make_platform
+    ):
+        """Test dev-loop prints warning when upload_run_after=true."""
+        mock_upload.return_value = 0
+        mock_monitor.return_value = ("output\n", 0, False)
+
+        platform = make_platform()
+        env = _make_env({"upload_run_after": True})
+        result = platform.on_dev_loop(target=Mock(), source=[Mock()], env=env)
+
+        assert result == 0
+        warning_found = any("upload_run_after" in str(call) for call in mock_print.call_args_list)
+        assert warning_found, "Expected warning about upload_run_after double-execution"
+
+
+class TestOnDevLoopSuccess:
+    """Test on_dev_loop full success path."""
+
+    @patch("builtins.open", mock_open())
+    @patch("os.makedirs")
+    @patch("platform_module.Linux_armPlatform._run_dev_loop_monitor")
+    @patch("platform_module.Linux_armPlatform.on_upload")
+    @patch("builtins.print")
+    def test_full_success_returns_zero(
+        self, _mock_print, mock_upload, mock_monitor, _mock_makedirs, make_platform
+    ):
+        """Test dev-loop returns 0 when all phases pass."""
+        mock_upload.return_value = 0
+        mock_monitor.return_value = ("Hello from ARM!\n", 0, False)
+
+        platform = make_platform()
+        env = _make_env()
+        result = platform.on_dev_loop(target=Mock(), source=[Mock()], env=env)
+
+        assert result == 0
+        mock_upload.assert_called_once()
+        mock_monitor.assert_called_once()
+
+    @patch("builtins.open", mock_open())
+    @patch("os.makedirs")
+    @patch("platform_module.Linux_armPlatform._run_dev_loop_monitor")
+    @patch("platform_module.Linux_armPlatform.on_upload")
+    @patch("builtins.print")
+    def test_json_output_contains_all_fields(
+        self, mock_print, mock_upload, mock_monitor, _mock_makedirs, make_platform
+    ):
+        """Test JSON output includes all required schema fields."""
+        mock_upload.return_value = 0
+        mock_monitor.return_value = ("test output\n", 0, False)
+
+        platform = make_platform()
+        env = _make_env()
+        platform.on_dev_loop(target=Mock(), source=[Mock()], env=env)
+
+        # Find the JSON output in print calls
+        json_str = None
+        for call in mock_print.call_args_list:
+            args = call[0]
+            if args and isinstance(args[0], str) and '"schema_version"' in args[0]:
+                json_str = args[0]
+                break
+
+        assert json_str is not None, "JSON output not found in print calls"
+        result = json.loads(json_str)
+
+        assert result["schema_version"] == "1"
+        assert "timestamp_iso" in result
+        assert "elapsed_seconds" in result
+        assert result["phases"]["build"]["status"] == "pass"
+        assert result["phases"]["upload"]["status"] == "pass"
+        assert result["phases"]["upload"]["error"] is None
+        assert result["phases"]["monitor"]["status"] == "pass"
+        assert result["phases"]["monitor"]["exit_code"] == 0
+        assert result["phases"]["monitor"]["timed_out"] is False
+        assert result["phases"]["monitor"]["timeout_seconds"] == 30
+        assert result["phases"]["monitor"]["output"] == "test output\n"
+        assert result["overall_status"] == "pass"
+        assert result["failure_phase"] is None
+
+
+class TestOnDevLoopUploadFailure:
+    """Test on_dev_loop when upload fails."""
+
+    @patch("builtins.open", mock_open())
+    @patch("os.makedirs")
+    @patch("platform_module.Linux_armPlatform._run_dev_loop_monitor")
+    @patch("platform_module.Linux_armPlatform.on_upload")
+    @patch("builtins.print")
+    def test_upload_exception_returns_one(
+        self, _mock_print, mock_upload, mock_monitor, _mock_makedirs, make_platform
+    ):
+        """Test dev-loop returns 1 when upload raises PlatformioException."""
+        mock_upload.side_effect = exception.PlatformioException("SSH connection failed")
+
+        platform = make_platform()
+        env = _make_env()
+        result = platform.on_dev_loop(target=Mock(), source=[Mock()], env=env)
+
+        assert result == 1
+        mock_monitor.assert_not_called()
+
+    @patch("builtins.open", mock_open())
+    @patch("os.makedirs")
+    @patch("platform_module.Linux_armPlatform._run_dev_loop_monitor")
+    @patch("platform_module.Linux_armPlatform.on_upload")
+    @patch("builtins.print")
+    def test_upload_failure_json_has_failure_phase(
+        self, mock_print, mock_upload, mock_monitor, _mock_makedirs, make_platform
+    ):
+        """Test JSON output has failure_phase='upload' when upload fails."""
+        mock_upload.side_effect = exception.PlatformioException("Connection refused")
+
+        platform = make_platform()
+        env = _make_env()
+        platform.on_dev_loop(target=Mock(), source=[Mock()], env=env)
+
+        # Find JSON in print calls
+        json_str = None
+        for call in mock_print.call_args_list:
+            args = call[0]
+            if args and isinstance(args[0], str) and '"schema_version"' in args[0]:
+                json_str = args[0]
+                break
+
+        assert json_str is not None
+        result = json.loads(json_str)
+
+        assert result["overall_status"] == "fail"
+        assert result["failure_phase"] == "upload"
+        assert result["phases"]["upload"]["status"] == "fail"
+        assert "Connection refused" in result["phases"]["upload"]["error"]
+        assert "monitor" not in result["phases"]
+
+    @patch("builtins.open", mock_open())
+    @patch("os.makedirs")
+    @patch("platform_module.Linux_armPlatform._run_dev_loop_monitor")
+    @patch("platform_module.Linux_armPlatform.on_upload")
+    @patch("builtins.print")
+    def test_upload_nonzero_rc_returns_one(
+        self, _mock_print, mock_upload, mock_monitor, _mock_makedirs, make_platform
+    ):
+        """Test dev-loop returns 1 when upload returns non-zero exit code."""
+        mock_upload.return_value = 1
+
+        platform = make_platform()
+        env = _make_env()
+        result = platform.on_dev_loop(target=Mock(), source=[Mock()], env=env)
+
+        assert result == 1
+        mock_monitor.assert_not_called()
+
+    @patch("builtins.open", mock_open())
+    @patch("os.makedirs")
+    @patch("platform_module.Linux_armPlatform._run_dev_loop_monitor")
+    @patch("platform_module.Linux_armPlatform.on_upload")
+    @patch("builtins.print")
+    def test_upload_oserror_returns_one(
+        self, _mock_print, mock_upload, mock_monitor, _mock_makedirs, make_platform
+    ):
+        """Test dev-loop returns 1 when upload raises OSError."""
+        mock_upload.side_effect = OSError("No such file or directory")
+
+        platform = make_platform()
+        env = _make_env()
+        result = platform.on_dev_loop(target=Mock(), source=[Mock()], env=env)
+
+        assert result == 1
+        mock_monitor.assert_not_called()
+
+    @patch("builtins.open", mock_open())
+    @patch("os.makedirs")
+    @patch("platform_module.Linux_armPlatform._run_dev_loop_monitor")
+    @patch("platform_module.Linux_armPlatform.on_upload")
+    @patch("builtins.print")
+    def test_upload_timeout_expired_returns_one(
+        self, _mock_print, mock_upload, mock_monitor, _mock_makedirs, make_platform
+    ):
+        """Test dev-loop returns 1 when upload raises subprocess.TimeoutExpired."""
+        mock_upload.side_effect = subprocess.TimeoutExpired(cmd="scp", timeout=60)
+
+        platform = make_platform()
+        env = _make_env()
+        result = platform.on_dev_loop(target=Mock(), source=[Mock()], env=env)
+
+        assert result == 1
+        mock_monitor.assert_not_called()
+
+
+class TestOnDevLoopMonitorTimeout:
+    """Test on_dev_loop when monitor times out."""
+
+    @patch("builtins.open", mock_open())
+    @patch("os.makedirs")
+    @patch("platform_module.Linux_armPlatform._run_dev_loop_monitor")
+    @patch("platform_module.Linux_armPlatform.on_upload")
+    @patch("builtins.print")
+    def test_monitor_timeout_json_has_timed_out(
+        self, mock_print, mock_upload, mock_monitor, _mock_makedirs, make_platform
+    ):
+        """Test JSON has timed_out=true when monitor exceeds timeout."""
+        mock_upload.return_value = 0
+        mock_monitor.return_value = ("partial output\n", -1, True)
+
+        platform = make_platform()
+        env = _make_env()
+        result = platform.on_dev_loop(target=Mock(), source=[Mock()], env=env)
+
+        # Timeout is not a failure — overall status is pass
+        assert result == 0
+
+        json_str = None
+        for call in mock_print.call_args_list:
+            args = call[0]
+            if args and isinstance(args[0], str) and '"schema_version"' in args[0]:
+                json_str = args[0]
+                break
+
+        parsed = json.loads(json_str)
+        assert parsed["phases"]["monitor"]["timed_out"] is True
+        assert parsed["phases"]["monitor"]["status"] == "timeout"
+        assert parsed["overall_status"] == "pass"
+
+
+class TestOnDevLoopMonitorNonZeroExit:
+    """Test on_dev_loop when remote program returns non-zero exit code."""
+
+    @patch("builtins.open", mock_open())
+    @patch("os.makedirs")
+    @patch("platform_module.Linux_armPlatform._run_dev_loop_monitor")
+    @patch("platform_module.Linux_armPlatform.on_upload")
+    @patch("builtins.print")
+    def test_monitor_nonzero_exit_returns_one(
+        self, mock_print, mock_upload, mock_monitor, _mock_makedirs, make_platform
+    ):
+        """Test dev-loop returns 1 when remote program exits with non-zero code."""
+        mock_upload.return_value = 0
+        mock_monitor.return_value = ("error output\n", 1, False)
+
+        platform = make_platform()
+        env = _make_env()
+        result = platform.on_dev_loop(target=Mock(), source=[Mock()], env=env)
+
+        assert result == 1
+
+        json_str = None
+        for call in mock_print.call_args_list:
+            args = call[0]
+            if args and isinstance(args[0], str) and '"schema_version"' in args[0]:
+                json_str = args[0]
+                break
+
+        parsed = json.loads(json_str)
+        assert parsed["phases"]["monitor"]["exit_code"] == 1
+        assert parsed["phases"]["monitor"]["status"] == "fail"
+        assert parsed["overall_status"] == "fail"
+        assert parsed["failure_phase"] == "monitor"
+
+
+class TestOnDevLoopMonitorTimeoutConfig:
+    """Test on_dev_loop validation of dev_loop_monitor_timeout config value."""
+
+    @patch("builtins.open", mock_open())
+    @patch("os.makedirs")
+    @patch("platform_module.Linux_armPlatform._run_dev_loop_monitor")
+    @patch("platform_module.Linux_armPlatform.on_upload")
+    @patch("builtins.print")
+    def test_zero_timeout_raises(
+        self, _mock_print, mock_upload, _mock_monitor, _mock_makedirs, make_platform
+    ):
+        """Test on_dev_loop raises PlatformioException when timeout is 0."""
+        mock_upload.return_value = 0
+
+        platform = make_platform()
+        env = _make_env({"dev_loop_monitor_timeout": 0})
+
+        with pytest.raises(exception.PlatformioException, match="must be a positive integer"):
+            platform.on_dev_loop(target=Mock(), source=[Mock()], env=env)
+
+    @patch("builtins.open", mock_open())
+    @patch("os.makedirs")
+    @patch("platform_module.Linux_armPlatform._run_dev_loop_monitor")
+    @patch("platform_module.Linux_armPlatform.on_upload")
+    @patch("builtins.print")
+    def test_negative_timeout_raises(
+        self, _mock_print, mock_upload, _mock_monitor, _mock_makedirs, make_platform
+    ):
+        """Test on_dev_loop raises PlatformioException when timeout is negative."""
+        mock_upload.return_value = 0
+
+        platform = make_platform()
+        env = _make_env({"dev_loop_monitor_timeout": -1})
+
+        with pytest.raises(exception.PlatformioException, match="must be a positive integer"):
+            platform.on_dev_loop(target=Mock(), source=[Mock()], env=env)
+
+    @patch("builtins.open", mock_open())
+    @patch("os.makedirs")
+    @patch("platform_module.Linux_armPlatform._run_dev_loop_monitor")
+    @patch("platform_module.Linux_armPlatform.on_upload")
+    @patch("builtins.print")
+    def test_non_integer_timeout_raises(
+        self, _mock_print, mock_upload, _mock_monitor, _mock_makedirs, make_platform
+    ):
+        """Test on_dev_loop raises PlatformioException when timeout is not an integer."""
+        mock_upload.return_value = 0
+
+        platform = make_platform()
+        env = _make_env({"dev_loop_monitor_timeout": "abc"})
+
+        with pytest.raises(exception.PlatformioException, match="must be an integer"):
+            platform.on_dev_loop(target=Mock(), source=[Mock()], env=env)
+
+
+class TestRunDevLoopMonitor:
+    """Test _run_dev_loop_monitor method."""
+
+    @patch("platform_module.subprocess.Popen")
+    @patch("builtins.print")
+    def test_successful_execution(self, _mock_print, mock_popen, make_platform):
+        """Test monitor captures output and returns exit code 0."""
+        mock_process = Mock()
+        mock_process.communicate.return_value = (b"Hello from ARM!\n", None)
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        platform = make_platform()
+        env = _make_env()
+        source_path = os.path.join(tempfile.gettempdir(), "build", "program")
+        output, exit_code, timed_out = platform._run_dev_loop_monitor(
+            env, [source_path], timeout=30
+        )
+
+        assert output == "Hello from ARM!\n"
+        assert exit_code == 0
+        assert timed_out is False
+
+    @patch("platform_module.subprocess.Popen")
+    @patch("builtins.print")
+    def test_timeout_kills_process(self, _mock_print, mock_popen, make_platform):
+        """Test monitor kills process and sets timed_out on TimeoutExpired."""
+        mock_process = Mock()
+        mock_process.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="ssh", timeout=30),
+            (b"partial\n", None),
+        ]
+        mock_process.returncode = None
+        mock_popen.return_value = mock_process
+
+        platform = make_platform()
+        env = _make_env()
+        source_path = os.path.join(tempfile.gettempdir(), "build", "program")
+        output, exit_code, timed_out = platform._run_dev_loop_monitor(
+            env, [source_path], timeout=30
+        )
+
+        assert timed_out is True
+        assert exit_code == -1
+        assert output == "partial\n"
+        mock_process.kill.assert_called_once()
+
+    @patch("platform_module.subprocess.Popen")
+    @patch("builtins.print")
+    def test_timeout_kills_process_inner_timeout(self, _mock_print, mock_popen, make_platform):
+        """Test monitor handles case where post-kill communicate also times out."""
+        mock_process = Mock()
+        mock_process.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="ssh", timeout=30),
+            subprocess.TimeoutExpired(cmd="ssh", timeout=10),
+        ]
+        mock_process.returncode = None
+        mock_popen.return_value = mock_process
+
+        platform = make_platform()
+        env = _make_env()
+        source_path = os.path.join(tempfile.gettempdir(), "build", "program")
+        output, exit_code, timed_out = platform._run_dev_loop_monitor(
+            env, [source_path], timeout=30
+        )
+
+        assert timed_out is True
+        assert output == ""
+        assert exit_code == -1
+        mock_process.kill.assert_called_once()
+
+    @patch("platform_module.subprocess.Popen")
+    @patch("builtins.print")
+    def test_output_sanitization(self, _mock_print, mock_popen, make_platform):
+        """Test non-printable characters are stripped from output."""
+        mock_process = Mock()
+        # Include control characters that should be stripped
+        mock_process.communicate.return_value = (
+            b"clean\x00text\x01with\x02control\x07chars\n",
+            None,
+        )
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        platform = make_platform()
+        env = _make_env()
+        source_path = os.path.join(tempfile.gettempdir(), "build", "program")
+        output, _, _ = platform._run_dev_loop_monitor(env, [source_path], timeout=30)
+
+        assert "\x00" not in output
+        assert "\x01" not in output
+        assert "\x07" not in output
+        assert "cleantextwithcontrolchars\n" == output
+
+    @patch("platform_module.subprocess.Popen")
+    @patch("builtins.print")
+    def test_output_truncation(self, _mock_print, mock_popen, make_platform):
+        """Test output exceeding MAX_OUTPUT_BYTES is truncated."""
+        from platform_constants import DevLoopConstants
+
+        large_output = b"x" * (DevLoopConstants.MAX_OUTPUT_BYTES + 1000)
+        mock_process = Mock()
+        mock_process.communicate.return_value = (large_output, None)
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        platform = make_platform()
+        env = _make_env()
+        source_path = os.path.join(tempfile.gettempdir(), "build", "program")
+        output, _, _ = platform._run_dev_loop_monitor(env, [source_path], timeout=30)
+
+        assert len(output) <= DevLoopConstants.MAX_OUTPUT_BYTES + len("\n[truncated]")
+        assert output.endswith("\n[truncated]")
+
+    def test_no_upload_port_raises(self, make_platform):
+        """Test monitor raises PlatformioException when upload_port is not configured."""
+        platform = make_platform()
+        env = _make_env({"upload_port": None})
+
+        source_path = os.path.join(tempfile.gettempdir(), "build", "program")
+        with pytest.raises(exception.PlatformioException, match="upload_port"):
+            platform._run_dev_loop_monitor(env, [source_path], timeout=30)
+
+    @patch("platform_module.subprocess.Popen")
+    @patch("builtins.print")
+    def test_custom_run_command(self, _mock_print, mock_popen, make_platform):
+        """Test upload_run_command is passed unquoted for remote execution."""
+        mock_process = Mock()
+        mock_process.communicate.return_value = (b"custom output\n", None)
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        platform = make_platform()
+        env = _make_env({"upload_run_command": "/usr/local/bin/myapp --flag"})
+        source_path = os.path.join(tempfile.gettempdir(), "build", "program")
+        output, exit_code, timed_out = platform._run_dev_loop_monitor(
+            env, [source_path], timeout=30
+        )
+
+        assert exit_code == 0
+        assert output == "custom output\n"
+        mock_popen.assert_called_once()
+        # Verify run command appears unquoted in SSH args (trusted user input)
+        cmd = mock_popen.call_args[0][0]
+        assert "/usr/local/bin/myapp --flag" in " ".join(cmd)
+
+    @patch("platform_module.subprocess.Popen")
+    @patch("builtins.print")
+    def test_remote_path_with_trailing_slash(self, _mock_print, mock_popen, make_platform):
+        """Test program name is appended when remote path ends with /."""
+        mock_process = Mock()
+        mock_process.communicate.return_value = (b"ok\n", None)
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        platform = make_platform()
+        env = _make_env({"upload_port": "pi@host:/home/pi/apps/"})
+        source_path = os.path.join(tempfile.gettempdir(), "build", "program")
+        output, exit_code, timed_out = platform._run_dev_loop_monitor(
+            env, [source_path], timeout=30
+        )
+
+        assert exit_code == 0
+        mock_popen.assert_called_once()
+        # Verify program name was appended to remote path
+        cmd = mock_popen.call_args[0][0]
+        assert "/home/pi/apps/program" in " ".join(cmd)
+
+    @patch("platform_module.subprocess.Popen")
+    @patch("builtins.print")
+    def test_remote_path_without_trailing_slash(self, _mock_print, mock_popen, make_platform):
+        """Test remote path used directly when no trailing slash."""
+        mock_process = Mock()
+        mock_process.communicate.return_value = (b"ok\n", None)
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        platform = make_platform()
+        env = _make_env({"upload_port": "pi@host:/home/pi/myapp"})
+        source_path = os.path.join(tempfile.gettempdir(), "build", "program")
+        output, exit_code, timed_out = platform._run_dev_loop_monitor(
+            env, [source_path], timeout=30
+        )
+
+        assert exit_code == 0
+        mock_popen.assert_called_once()
+        # Verify remote path used as-is (no program name appended)
+        cmd = mock_popen.call_args[0][0]
+        assert "/home/pi/myapp" in " ".join(cmd)
+
+    def test_ssh_config_error_returns_error(self, make_platform):
+        """Test monitor returns error when SSHConnectionConfig raises ValueError."""
+        platform = make_platform()
+        env = _make_env({"upload_port": "pi@host:/path"})
+
+        source_path = os.path.join(tempfile.gettempdir(), "build", "program")
+        with patch(
+            "ssh_utils.SSHConnectionConfig",
+            side_effect=ValueError("Invalid SSH key path"),
+        ):
+            output, exit_code, timed_out = platform._run_dev_loop_monitor(
+                env, [source_path], timeout=30
+            )
+
+        assert exit_code == 1
+        assert "SSH config error" in output
+        assert "Invalid SSH key path" in output
+
+    def test_ssh_config_file_not_found_returns_error(self, make_platform):
+        """Test monitor returns error when SSHConnectionConfig raises FileNotFoundError."""
+        platform = make_platform()
+        env = _make_env({"upload_port": "pi@host:/path"})
+
+        source_path = os.path.join(tempfile.gettempdir(), "build", "program")
+        with patch(
+            "ssh_utils.SSHConnectionConfig",
+            side_effect=FileNotFoundError("Key file not found"),
+        ):
+            output, exit_code, timed_out = platform._run_dev_loop_monitor(
+                env, [source_path], timeout=30
+            )
+
+        assert exit_code == 1
+        assert "SSH config error" in output
+
+
+class TestIsoTimestamp:
+    """Test _iso_timestamp static method."""
+
+    def test_returns_valid_iso8601(self, make_platform):
+        """Test _iso_timestamp returns a valid ISO 8601 string with timezone."""
+        platform = make_platform()
+        ts = platform._iso_timestamp()
+        parsed = datetime.datetime.fromisoformat(ts)
+        assert parsed.tzinfo is not None
+
+    def test_returns_recent_timestamp(self, make_platform):
+        """Test _iso_timestamp returns the current time."""
+        platform = make_platform()
+        fixed_now = datetime.datetime(2024, 1, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        with patch("platform_module.datetime") as mock_dt:
+            mock_dt.datetime.now.return_value = fixed_now
+            mock_dt.timezone.utc = datetime.timezone.utc
+            ts = platform._iso_timestamp()
+        assert ts == fixed_now.astimezone().isoformat()
+
+
+class TestEmitDevLoopResultFailure:
+    """Test _emit_dev_loop_result error handling."""
+
+    @patch("os.makedirs", side_effect=OSError("Permission denied"))
+    @patch("builtins.print")
+    def test_file_write_oserror_prints_warning(self, mock_print, mock_makedirs, make_platform):
+        """Test _emit_dev_loop_result prints warning on OSError without raising."""
+        platform = make_platform()
+        env = _make_env()
+        result = {"schema_version": "1", "overall_status": "pass"}
+
+        # Should not raise
+        platform._emit_dev_loop_result(result, env)
+
+        # Verify warning was printed
+        warning_found = False
+        for call in mock_print.call_args_list:
+            args = call[0]
+            if args and isinstance(args[0], str) and "Warning:" in args[0]:
+                warning_found = True
+                break
+        assert warning_found, "Expected warning message about file write failure"
+
+
+class TestDevLoopHandlerFallback:
+    """Test _dev_loop_handler fallback when platform lacks on_dev_loop.
+
+    builder/main.py is a SCons script (uses DefaultEnvironment(), Import())
+    and cannot be directly imported. We extract _dev_loop_handler via AST +
+    compile so the test exercises the real function, not a reimplementation.
+    """
+
+    @staticmethod
+    def _load_handler():
+        """Extract _dev_loop_handler from builder/main.py source."""
+        import ast
+
+        builder_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "builder",
+            "main.py",
+        )
+        with open(builder_path) as f:
+            source = f.read()
+
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "_dev_loop_handler":
+                func_source = ast.get_source_segment(source, node)
+                assert func_source is not None, (
+                    "_dev_loop_handler source could not be extracted from builder/main.py. "
+                    "The function may have been renamed or relocated."
+                )
+                code = compile(func_source, builder_path, "exec")
+                namespace: dict = {}
+                # Safe: source is version-controlled own-codebase, no user input
+                exec(code, namespace)  # nosec B102
+                return namespace["_dev_loop_handler"]
+        raise RuntimeError("_dev_loop_handler not found in builder/main.py")
+
+    @patch("builtins.print")
+    def test_no_on_dev_loop_returns_one(self, mock_print):
+        """Test handler returns 1 when platform has no on_dev_loop method."""
+        handler = self._load_handler()
+
+        mock_env = Mock()
+        mock_platform = Mock(spec=[])  # Empty spec = no attributes
+        mock_env.PioPlatform.return_value = mock_platform
+
+        result = handler(Mock(), [Mock()], mock_env)
+        assert result == 1
+
+    @patch("builtins.print")
+    def test_has_on_dev_loop_dispatches_and_returns_value(self, mock_print):
+        """Test handler dispatches to on_dev_loop and returns its return value."""
+        handler = self._load_handler()
+
+        mock_env = Mock()
+        mock_platform = Mock()  # Has on_dev_loop by default (Mock has all attrs)
+        mock_platform.on_dev_loop.return_value = 42
+        mock_env.PioPlatform.return_value = mock_platform
+
+        target = Mock()
+        source = [Mock()]
+        result = handler(target, source, mock_env)
+
+        mock_platform.on_dev_loop.assert_called_once_with(target, source, mock_env)
+        assert result == 42
+
+
+class TestDevLoopResultFile:
+    """Test result file writing."""
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("os.makedirs")
+    @patch("platform_module.Linux_armPlatform._run_dev_loop_monitor")
+    @patch("platform_module.Linux_armPlatform.on_upload")
+    @patch("builtins.print")
+    def test_result_file_written(
+        self,
+        mock_print,
+        mock_upload,
+        mock_monitor,
+        mock_makedirs,
+        mock_file,
+        make_platform,
+    ):
+        """Test result JSON is written to BUILD_DIR/dev-loop-result.json."""
+        mock_upload.return_value = 0
+        mock_monitor.return_value = ("output\n", 0, False)
+
+        platform = make_platform()
+        env = _make_env()
+        platform.on_dev_loop(target=Mock(), source=[Mock()], env=env)
+
+        build_dir = os.path.join(tempfile.gettempdir(), "build_dir")
+        mock_makedirs.assert_called_once_with(build_dir, exist_ok=True)
+        from platform_constants import DevLoopConstants
+
+        mock_file.assert_called_with(
+            os.path.join(build_dir, DevLoopConstants.RESULT_FILENAME), "w", encoding="utf-8"
+        )
+
+
+class TestBuildSshExecuteCmd:
+    """Test _build_ssh_execute_cmd static method directly."""
+
+    def _make_config(self):
+        config = Mock()
+        config.host = "raspberrypi.local"
+        config.user = "pi"
+        config.port = 22
+        config.key_file = None
+        config.strict_host_check = False
+        return config
+
+    @patch("ssh_utils.SSHCommandBuilder")
+    def test_trailing_slash_appends_program_name(self, mock_builder_cls):
+        """Test program name is appended to remote path when it ends with /."""
+        from platform_module import Linux_armPlatform
+
+        mock_builder = Mock()
+        mock_builder.build_ssh_command.return_value = [
+            "ssh",
+            "pi@host",
+            "/home/pi/apps/program",
+        ]
+        mock_builder_cls.return_value = mock_builder
+
+        config = self._make_config()
+        env = Mock()
+        env.GetProjectOption.return_value = None
+
+        source_path = os.path.join(tempfile.gettempdir(), "build", "program")
+        cmd, display_path = Linux_armPlatform._build_ssh_execute_cmd(
+            config, env, "/home/pi/apps/", [source_path]
+        )
+
+        call_args = mock_builder.build_ssh_command.call_args[0][0]
+        assert "program" in call_args
+        assert display_path == "/home/pi/apps/program"
+
+    @patch("ssh_utils.SSHCommandBuilder")
+    def test_no_trailing_slash_uses_path_directly(self, mock_builder_cls):
+        """Test remote path is used as-is when it does not end with /."""
+        from platform_module import Linux_armPlatform
+
+        mock_builder = Mock()
+        mock_builder.build_ssh_command.return_value = [
+            "ssh",
+            "pi@host",
+            "/home/pi/myapp",
+        ]
+        mock_builder_cls.return_value = mock_builder
+
+        config = self._make_config()
+        env = Mock()
+        env.GetProjectOption.return_value = None
+
+        source_path = os.path.join(tempfile.gettempdir(), "build", "program")
+        cmd, display_path = Linux_armPlatform._build_ssh_execute_cmd(
+            config, env, "/home/pi/myapp", [source_path]
+        )
+
+        call_args = mock_builder.build_ssh_command.call_args[0][0]
+        assert "myapp" in call_args
+        assert display_path == "/home/pi/myapp"
+
+    @patch("ssh_utils.SSHCommandBuilder")
+    def test_custom_run_command_passed_unquoted(self, mock_builder_cls):
+        """Test upload_run_command is passed through without shell-quoting."""
+        from platform_module import Linux_armPlatform
+
+        mock_builder = Mock()
+        mock_builder.build_ssh_command.return_value = [
+            "ssh",
+            "pi@host",
+            "/usr/bin/myapp --flag",
+        ]
+        mock_builder_cls.return_value = mock_builder
+
+        config = self._make_config()
+        env = Mock()
+        env.GetProjectOption.return_value = "/usr/bin/myapp --flag"
+
+        cmd, display_path = Linux_armPlatform._build_ssh_execute_cmd(config, env, "/home/pi/", None)
+
+        call_args = mock_builder.build_ssh_command.call_args[0][0]
+        assert call_args == "/usr/bin/myapp --flag"
+        assert display_path == "/usr/bin/myapp --flag"
+
+
+class TestScrubErrorMessage:
+    """Test _scrub_error_message static method directly."""
+
+    def test_redacts_unix_absolute_path(self):
+        """Test Unix absolute paths are redacted."""
+        from platform_module import Linux_armPlatform
+
+        result = Linux_armPlatform._scrub_error_message(
+            "Permission denied (publickey): /home/user/.ssh/id_rsa"
+        )
+        assert "/home/user/.ssh/id_rsa" not in result
+        assert "[redacted]" in result
+
+    def test_redacts_user_at_host(self):
+        """Test user@host patterns are redacted."""
+        from platform_module import Linux_armPlatform
+
+        result = Linux_armPlatform._scrub_error_message(
+            "Connection refused by pi@raspberrypi.local"
+        )
+        assert "pi@raspberrypi.local" not in result
+        assert "[redacted]" in result
+
+    def test_redacts_windows_path(self):
+        """Test Windows-style absolute paths are redacted."""
+        from platform_module import Linux_armPlatform
+
+        result = Linux_armPlatform._scrub_error_message(
+            r"Key not found: C:\Users\testuser\.ssh\id_rsa"
+        )
+        assert r"C:\Users\testuser\.ssh\id_rsa" not in result
+        assert "[redacted]" in result
+
+    def test_preserves_plain_error_text(self):
+        """Test messages without paths or hostnames are unchanged."""
+        from platform_module import Linux_armPlatform
+
+        msg = "Connection refused"
+        result = Linux_armPlatform._scrub_error_message(msg)
+        assert result == msg
+
+    def test_redacts_multiple_paths(self):
+        """Test multiple paths in a single message are all redacted."""
+        from platform_module import Linux_armPlatform
+
+        result = Linux_armPlatform._scrub_error_message(
+            "Could not read /etc/ssh/sshd_config or /root/.ssh/authorized_keys"
+        )
+        assert "/etc/ssh/sshd_config" not in result
+        assert "/root/.ssh/authorized_keys" not in result
+
+    def test_redacts_relative_ssh_path(self):
+        """Test relative paths containing .ssh are redacted."""
+        from platform_module import Linux_armPlatform
+
+        result = Linux_armPlatform._scrub_error_message("Could not open key file: keys/deploy_key")
+        assert "keys/deploy_key" not in result
+        assert "[redacted]" in result
+
+    def test_redacts_unc_path(self):
+        """Test Windows UNC paths are redacted."""
+        from platform_module import Linux_armPlatform
+
+        result = Linux_armPlatform._scrub_error_message(
+            r"Key not found at \\server\share\keys\id_rsa"
+        )
+        assert r"\\server\share\keys\id_rsa" not in result
+        assert "[redacted]" in result

--- a/tests/test_platform_constants.py
+++ b/tests/test_platform_constants.py
@@ -24,7 +24,7 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-import platform_constants
+import platform_constants  # noqa: E402
 
 
 class TestToolchainPrefixPosix:
@@ -136,3 +136,22 @@ class TestStaticConstants:
         for attr in ["UPLOAD", "UPLOAD_RUN", "TEST_UPLOAD", "TEST_EXECUTION", "CHMOD"]:
             value = getattr(platform_constants.Timeouts, attr)
             assert isinstance(value, int) and value > 0, f"Timeouts.{attr} = {value}"
+
+
+class TestDevLoopConstants:
+    """Test dev-loop constant values that agents parse — silent drift is a real risk."""
+
+    def test_schema_version(self):
+        assert platform_constants.DevLoopConstants.SCHEMA_VERSION == "1"
+
+    def test_output_delimiter(self):
+        assert platform_constants.DevLoopConstants.OUTPUT_DELIMITER == "--- DEV_LOOP_RESULT ---"
+
+    def test_result_filename(self):
+        assert platform_constants.DevLoopConstants.RESULT_FILENAME == "dev-loop-result.json"
+
+    def test_max_output_bytes(self):
+        assert platform_constants.DevLoopConstants.MAX_OUTPUT_BYTES == 64 * 1024
+
+    def test_monitor_timeout(self):
+        assert platform_constants.DevLoopConstants.MONITOR_TIMEOUT == 30


### PR DESCRIPTION
## Description

Adds a `dev-loop` SCons target to `Linux_armPlatform` that chains build → upload → monitor in a single invocation and emits structured JSON output to `BUILD_DIR/dev-loop-result.json` for AI agent consumption.

Key implementation details:
- `on_dev_loop()` orchestrates the three phases and writes a structured result file
- `_run_dev_loop_monitor()` captures remote program stdout/stderr with timeout
- `_build_ssh_execute_cmd()` shared by interactive and capture modes (no duplication)
- `_scrub_error_message()` redacts paths/credentials from persisted error fields
- `_emit_dev_loop_result()` writes JSON to `BUILD_DIR/dev-loop-result.json`
- `dev_loop_monitor_timeout` config option (default: 30 s)
- Bounds-check on `monitor_timeout` rejects zero/negative values
- `subprocess.TimeoutExpired` caught at upload phase as defence-in-depth so a structured JSON result is always emitted (built-in protocols already wrap this as `PlatformioException`)

## Type of Change

- [ ] [FIX] Bug fix (non-breaking change which fixes an issue)
- [x] [FEATURE] New feature (non-breaking change which adds functionality)
- [ ] [BREAKING] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] [DOCS] Documentation update
- [ ] [STYLE] Code style update (formatting, renaming)
- [ ] [REFACTOR] Refactoring (no functional changes)
- [ ] [BUILD] Build/CI configuration change
- [ ] [PERF] Performance improvement
- [x] [TEST] Test update

## Related Issues

Closes #112

## Checklist

### Testing

- [x] I have tested my changes locally
- [x] I have built all examples successfully
- [ ] I have tested on target hardware (if applicable)
- [x] All CI/CD checks pass
- [ ] I have tested both 32-bit and 64-bit builds (if applicable)

### Code Quality

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly
- [x] I have updated CONTRIBUTING.md if needed
- [x] I have updated the README.md if needed
- [ ] I have added or updated board definitions if needed
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) specification

### Board Changes (if applicable)

N/A — no board changes.

### Framework Changes (if applicable)

N/A — no framework changes.

## Test Results

### Build Test Results

38 unit tests added in `tests/test_dev_loop.py` covering:

- `TestOnDevLoopSuccess` — full success path with JSON schema validation
- `TestOnDevLoopUploadFailure` — upload exception, non-zero rc, OSError, TimeoutExpired
- `TestOnDevLoopMonitorTimeout` — `timed_out` flag in JSON output
- `TestOnDevLoopMonitorNonZeroExit` — `failure_phase=monitor` in JSON output
- `TestOnDevLoopMonitorTimeoutConfig` — zero/negative timeout raises `PlatformioException`
- `TestRunDevLoopMonitor` — output capture, timeout/kill, sanitisation, truncation, SSH config errors, custom run command
- `TestBuildSshExecuteCmd` — trailing slash, no slash, custom run command
- `TestScrubErrorMessage` — absolute/relative/UNC paths, user@host, multi-path

```
38 passed in 0.31s
```

All pre-commit hooks pass (black, ruff, isort, pydocstyle, markdownlint).

## Additional Notes

- `dev-loop-result.json` is written to `.pio/build/<env>/` which is already covered by `.gitignore`
- `AGENTS.md` documents the JSON schema, config reference, and agent integration patterns for consumers of the result file
- `docs/CONFIGURATION.md` documents `dev_loop_monitor_timeout`; `CONTRIBUTING.md` now includes the `dev-loop` commit scope

## Breaking Changes

None. The `dev-loop` target is additive; all existing targets (`upload`, `monitor`, `remote-test`) are unchanged.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**