### PR TITLE
fix(lgpio): add PWM HAL unit tests via sysfs seam, enforce lint/mypy, fix #118 #119

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -66,6 +66,16 @@ Please ensure your PR meets the following requirements:
 - [ ] I have updated framework documentation
 - [ ] I have tested on multiple Pi models (if applicable)
 
+### AI-Assisted Contributions (if applicable)
+
+If this PR was created or substantially modified with AI assistance (Claude, Copilot, Codex, etc.):
+
+- [ ] I have disclosed the AI tool(s) used and the scope of assistance in the description above
+- [ ] I have reviewed and understand all AI-generated code in this PR
+- [ ] I have noted the degree of testing (untested / lightly tested / fully tested)
+- [ ] AI `Co-Authored-By:` commit trailers have been removed before submitting
+- [ ] If hardware was involved, I have noted whether it was tested on real hardware or build-only
+
 ## Test Results
 
 <!-- Describe the tests you ran and the results -->

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -15,7 +15,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
@@ -112,7 +112,7 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
           submodules: "recursive"
 
@@ -604,7 +604,7 @@ jobs:
     name: C unit tests (ArduinoBridge + PWM HAL)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
       - name: Install dependencies
         run: sudo apt-get install -y cmake build-essential libmsgpack-cxx-dev

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -7,6 +7,7 @@ on:
       - develop
       - 'claude/**'
       - 'feature/**'
+      - 'fix/**'
   pull_request:
 
 jobs:
@@ -17,7 +18,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
         with:
           python-version: '3.11'
 
@@ -69,6 +70,8 @@ jobs:
           - examples/baremetal-hello
           - examples/baremetal-threads
           - examples/lgpio-blink
+          - examples/lgpio-pwm-fade
+          - examples/lgpio-pwm-servo
           - examples/libgpiod-blink
           - examples/libgpiod-blink-v2
           - examples/libgpiod-button
@@ -80,6 +83,14 @@ jobs:
           # Exclude lgpio on Windows (complex cross-compile setup)
           - os: windows-latest
             example: examples/lgpio-blink
+
+          # Exclude lgpio-pwm-fade on Windows (complex cross-compile setup)
+          - os: windows-latest
+            example: examples/lgpio-pwm-fade
+
+          # Exclude lgpio-pwm-servo on Windows (complex cross-compile setup)
+          - os: windows-latest
+            example: examples/lgpio-pwm-servo
 
           # Exclude arduino-uno-q-hello on Windows (AArch64 cross-compile not configured for Windows CI)
           - os: windows-latest
@@ -105,7 +116,7 @@ jobs:
         with:
           submodules: "recursive"
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
         with:
           python-version: "3.11"
 
@@ -436,7 +447,7 @@ jobs:
       # and the linker would fall back to the 32-bit .so producing "file format not
       # recognized".
       - name: Cache lgpio library (32-bit, Ubuntu/macOS)
-        if: matrix.os != 'windows-latest' && matrix.example == 'examples/lgpio-blink'
+        if: matrix.os != 'windows-latest' && contains(matrix.example, 'lgpio')
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         id: cache-lgpio-armhf
         with:
@@ -447,7 +458,7 @@ jobs:
 
       # Cache built lgpio library (64-bit, Ubuntu/macOS)
       - name: Cache lgpio library (64-bit, Ubuntu/macOS)
-        if: matrix.os != 'windows-latest' && matrix.example == 'examples/lgpio-blink'
+        if: matrix.os != 'windows-latest' && contains(matrix.example, 'lgpio')
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         id: cache-lgpio-aarch64
         with:
@@ -458,7 +469,7 @@ jobs:
 
       # Build lgpio for ARM cross-compilation (32-bit) - Ubuntu only
       - name: Build lgpio for ARM cross-compilation (32-bit) - Ubuntu
-        if: matrix.os == 'ubuntu-latest' && matrix.example == 'examples/lgpio-blink' && steps.cache-lgpio-armhf.outputs.cache-hit != 'true'
+        if: matrix.os == 'ubuntu-latest' && contains(matrix.example, 'lgpio') && steps.cache-lgpio-armhf.outputs.cache-hit != 'true'
         shell: bash
         run: |
           echo "Building lgpio library for ARM 32-bit..."
@@ -468,7 +479,7 @@ jobs:
       # macOS brew toolchain uses arm-unknown-linux-gnueabihf- prefix (not arm-linux-gnueabihf-)
       # Install to arm-linux-gnueabihf so the lgpio framework builder finds it
       - name: Build lgpio for ARM cross-compilation (32-bit) - macOS
-        if: matrix.os == 'macos-latest' && matrix.example == 'examples/lgpio-blink' && steps.cache-lgpio-armhf.outputs.cache-hit != 'true'
+        if: matrix.os == 'macos-latest' && contains(matrix.example, 'lgpio') && steps.cache-lgpio-armhf.outputs.cache-hit != 'true'
         shell: bash
         run: |
           echo "Building lgpio library for ARM 32-bit on macOS..."
@@ -478,7 +489,7 @@ jobs:
 
       # Build lgpio for ARM cross-compilation (64-bit) - Ubuntu only
       - name: Build lgpio for ARM cross-compilation (64-bit) - Ubuntu
-        if: matrix.os == 'ubuntu-latest' && matrix.example == 'examples/lgpio-blink' && steps.cache-lgpio-aarch64.outputs.cache-hit != 'true'
+        if: matrix.os == 'ubuntu-latest' && contains(matrix.example, 'lgpio') && steps.cache-lgpio-aarch64.outputs.cache-hit != 'true'
         shell: bash
         run: |
           echo "Building lgpio library for ARM 64-bit..."
@@ -490,7 +501,7 @@ jobs:
       # macOS brew toolchain uses aarch64-unknown-linux-gnu- prefix (not aarch64-linux-gnu-)
       # Install to aarch64-linux-gnu so the lgpio framework builder finds it
       - name: Build lgpio for ARM cross-compilation (64-bit) - macOS
-        if: matrix.os == 'macos-latest' && matrix.example == 'examples/lgpio-blink' && steps.cache-lgpio-aarch64.outputs.cache-hit != 'true'
+        if: matrix.os == 'macos-latest' && contains(matrix.example, 'lgpio') && steps.cache-lgpio-aarch64.outputs.cache-hit != 'true'
         shell: bash
         run: |
           echo "Building lgpio library for ARM 64-bit on macOS..."
@@ -578,7 +589,7 @@ jobs:
           echo "MRAA artifacts verified."
 
       - name: Install PlatformIO Core
-        run: pip install -U platformio
+        run: pip install "platformio>=6.1.0,<7.0.0"
 
       - name: Install platform (symlink mode)
         run: pio pkg install --global --platform symlink://.
@@ -590,16 +601,19 @@ jobs:
         run: pio run -d "$EXAMPLE_PATH"
 
   cpp-tests:
-    name: C++ unit tests (ArduinoBridge)
+    name: C unit tests (ArduinoBridge + PWM HAL)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install dependencies
-        run: sudo apt-get install -y libmsgpack-dev cmake
+        run: sudo apt-get install -y cmake build-essential libmsgpack-cxx-dev
 
       - name: Build
         run: cmake -B build -DCMAKE_BUILD_TYPE=Debug
 
-      - name: Run
-        run: cmake --build build --target test_arduino_bridge && ./build/test_arduino_bridge
+      - name: Build all C unit tests
+        run: cmake --build build
+
+      - name: Run all C unit tests
+        run: ctest --test-dir build --output-on-failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
@@ -66,7 +66,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
     - name: Install CMake build dependencies
       run: |
@@ -88,7 +88,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
@@ -126,7 +126,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [develop, main, master, 'claude/**']
+    branches: [develop, main, master, 'claude/**', 'fix/**', 'feature/**']
   pull_request:
 
 jobs:
@@ -32,7 +32,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -43,7 +43,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
         # Install platformio for testing platform integration
-        pip install platformio
+        pip install "platformio>=6.1.0,<7.0.0"
 
     - name: Run tests with pytest
       run: |
@@ -60,6 +60,28 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  c-unit-tests:
+    name: C Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+    - name: Install CMake build dependencies
+      run: |
+        sudo apt-get update -q
+        sudo apt-get install -y cmake build-essential libmsgpack-cxx-dev
+
+    - name: Configure CMake
+      run: cmake -B build -DCMAKE_BUILD_TYPE=Debug
+
+    - name: Build C unit tests
+      run: cmake --build build
+
+    - name: Run C unit tests
+      run: ctest --test-dir build --output-on-failure
+
   lint:
     name: Code Quality
     runs-on: ubuntu-latest
@@ -69,7 +91,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
       with:
         python-version: '3.12'
         cache: 'pip'
@@ -79,7 +101,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
-        pip install platformio
+        pip install "platformio>=6.1.0,<7.0.0"
 
     - name: Check code formatting with black
       run: |
@@ -107,7 +129,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
       with:
         python-version: '3.12'
         cache: 'pip'
@@ -117,14 +139,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
-        pip install platformio
 
     - name: Generate coverage report
       run: |
         pytest tests/ --cov=. --cov-report=html --cov-report=term
 
     - name: Archive coverage report
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v4
       with:
         name: coverage-report
         path: htmlcov/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,28 +60,6 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  c-unit-tests:
-    name: C Unit Tests
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-
-    - name: Install CMake build dependencies
-      run: |
-        sudo apt-get update -q
-        sudo apt-get install -y cmake build-essential libmsgpack-cxx-dev
-
-    - name: Configure CMake
-      run: cmake -B build -DCMAKE_BUILD_TYPE=Debug
-
-    - name: Build C unit tests
-      run: cmake --build build
-
-    - name: Run C unit tests
-      run: ctest --test-dir build --output-on-failure
-
   lint:
     name: Code Quality
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ MEMORY/
 
 # CMake build output
 build/
+
+# C in-tree object files (safety net for direct gcc invocations outside CMake)
+tests/**/*.o

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,16 @@ repos:
     rev: v1.33.0
     hooks:
       - id: yamllint
-        args: ['-d', '{extends: default, rules: {line-length: {max: 120}, document-start: disable, indentation: disable, truthy: disable, comments: disable}}']
+        # Disabled rules for GitHub Actions workflow YAML:
+        #   line-length: max 200  — CI YAML legitimately has long run: blocks
+        #   document-start: disable — '---' header is optional in GHA files
+        #   truthy: disable — GHA uses 'on:' as a trigger key; yamllint incorrectly
+        #                     flags it as a YAML boolean truthy value
+        #   indentation: disable — GHA workflows use valid but complex nested
+        #                          indentation that triggers false positives
+        #   comments: disable — inline '# vN' SHA-pinning comments violate
+        #                       yamllint's comment-spacing rule
+        args: ['-d', '{extends: default, rules: {line-length: {max: 200}, document-start: disable, indentation: disable, truthy: disable, comments: disable}}']
         files: ^\.github/workflows/.*\.ya?ml$
 
   # Python docstring checks (optional, can be removed if too strict)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ computers (Raspberry Pi, Orange Pi, BeagleBone, Radxa, Khadas, Arduino Uno Q).
 
 ## Repository Structure
 
-```
+```text
 platform-linux_arm/
 ├── platform.py              # PlatformIO platform entry point (Linux_armPlatform class)
 ├── platform_constants.py    # Architecture and toolchain prefix enums
@@ -29,7 +29,9 @@ platform-linux_arm/
 │   └── frameworks/          # One .py per framework (lgpio, libgpiod, arduino_bridge, …)
 ├── examples/                # 21 example projects (each is a standalone PlatformIO project)
 ├── scripts/                 # Setup scripts (setup-mraa-cross.sh, setup-lgpio-cross.sh, …)
-├── tests/                   # Python unit tests for builder scripts (pytest)
+├── tests/                   # Python unit tests (pytest) for builder scripts
+│                            #   and C unit tests (CMake/ctest) for framework C code
+│   └── stubs/               # C sysfs stubs for link-seam unit testing
 └── docs/                    # Documentation (boards, frameworks, security, upload, etc.)
 ```
 
@@ -92,12 +94,14 @@ This is how Pi 5 64-bit builds work: `board = raspberrypi_5` +
 Framework builders live in `builder/frameworks/`. Each is a Python SCons script.
 
 **Accessing the environment:**
+
 ```python
 from SCons.Script import DefaultEnvironment
 env = DefaultEnvironment()
 ```
 
 **Detecting target architecture:**
+
 ```python
 from utils import get_target_arch
 target_arch = get_target_arch(env)   # returns "armv7" or "aarch64"
@@ -105,6 +109,7 @@ is_aarch64 = target_arch == "aarch64"
 ```
 
 **Reading board config:**
+
 ```python
 board = env.BoardConfig()
 mcu = board.get("build.mcu", "")
@@ -112,6 +117,7 @@ arch = board.get("build.arch", "armv7")
 ```
 
 **Adding compile flags / libraries:**
+
 ```python
 env.Append(
     CPPPATH=["/path/to/include"],
@@ -126,6 +132,7 @@ env.Append(
 it via `env["_BINPREFIX"]`.
 
 **Installed library paths** follow this convention:
+
 - armv7: `~/.local/arm-linux-gnueabihf/`
 - aarch64: `~/.local/aarch64-linux-gnu/`
 
@@ -148,6 +155,7 @@ brew install arm-unknown-linux-gnueabihf aarch64-unknown-linux-gnu
 ### Framework Libraries
 
 **lgpio** (required for `lgpio` framework):
+
 ```bash
 ./scripts/setup-lgpio-cross.sh                                           # ARMv7
 CROSS_PREFIX=aarch64-linux-gnu- INSTALL_DIR=$HOME/.local/aarch64-linux-gnu \
@@ -155,6 +163,7 @@ CROSS_PREFIX=aarch64-linux-gnu- INSTALL_DIR=$HOME/.local/aarch64-linux-gnu \
 ```
 
 **MRAA** (required for `arduino-bridge` framework):
+
 ```bash
 # Recommended — auto-detects toolchain, from any arduino-bridge project directory:
 pio run --target setup-mraa
@@ -164,6 +173,7 @@ CROSS_PREFIX=aarch64-linux-gnu- ./scripts/setup-mraa-cross.sh           # AArch6
 ```
 
 **libgpiod** (required for `libgpiod` framework):
+
 ```bash
 ./scripts/setup-libgpiod-cross.sh                                        # ARMv7/AArch64
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ platform-linux_arm/
 ├── tests/                   # Python unit tests (pytest) for builder scripts
 │                            #   and C unit tests (CMake/ctest) for framework C code
 │   ├── test_platform.py     # pytest: builder script unit tests (83 tests)
-│   ├── test_pwm_hal.c       # ctest: PWM HAL C unit tests (29 tests, no hardware needed)
+│   ├── test_pwm_hal.c       # ctest: PWM HAL C unit tests (42 tests, no hardware needed)
 │   └── stubs/
 │       ├── pwm-hal-sysfs-stub.c  # Link-seam stub — replaces /sys/class/pwm/ with in-memory table
 │       └── pwm-hal-sysfs-stub.h  # Stub control API (stub_reset, stub_set_pi5, stub_set_export_delay)
@@ -222,11 +222,29 @@ pio run -e raspberrypi_4b_upload --target upload
 
 ## Testing
 
+### Python Unit Tests
+
 Python unit tests live in `tests/`. They test builder script logic without
 running a full PlatformIO build. Run with `pytest`.
 
 CI runs tests on ubuntu-latest, macos-latest, windows-latest with Python
 3.10, 3.11, 3.12 (see `.github/workflows/tests.yml`).
+
+### C Unit Tests (CMake)
+
+The `framework-lgpio/pwm-hal` module has a C unit test suite (`tests/test_pwm_hal.c`)
+that runs without Raspberry Pi hardware. A link-seam stub (`tests/stubs/pwm-hal-sysfs-stub.c`)
+replaces all `/sys/class/pwm` I/O with in-memory state.
+
+Build and run:
+
+```bash
+cmake -B build
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+CI job: `c-unit-tests` in `.github/workflows/tests.yml`.
 
 Example builds are validated by `.github/workflows/examples.yml` across the
 same OS matrix.
@@ -276,6 +294,7 @@ Follows [Conventional Commits](https://www.conventionalcommits.org/).
 |----------|---------|-------------|
 | `examples.yml` | push, PR | Builds all 21 examples × {ubuntu, macos, windows} |
 | `tests.yml` | push, PR | Python pytest × {ubuntu, macos, windows} × Python {3.10, 3.11, 3.12} |
+| `tests.yml` | push, PR | C unit tests (CMake/ctest, 46 tests, ubuntu-latest) |
 | `release.yml` | tag push | Publishes platform package |
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ platform-linux_arm/
 ├── tests/                   # Python unit tests (pytest) for builder scripts
 │                            #   and C unit tests (CMake/ctest) for framework C code
 │   ├── test_platform.py     # pytest: builder script unit tests (83 tests)
-│   ├── test_pwm_hal.c       # ctest: PWM HAL C unit tests (42 tests, no hardware needed)
+│   ├── test_pwm_hal.c       # ctest: PWM HAL C unit tests (50 tests, no hardware needed)
 │   └── stubs/
 │       ├── pwm-hal-sysfs-stub.c  # Link-seam stub — replaces /sys/class/pwm/ with in-memory table
 │       └── pwm-hal-sysfs-stub.h  # Stub control API (stub_reset, stub_set_pi5, stub_set_export_delay)
@@ -244,7 +244,7 @@ cmake --build build
 ctest --test-dir build --output-on-failure
 ```
 
-CI job: `c-unit-tests` in `.github/workflows/tests.yml`.
+CI job: `cpp-tests` in `.github/workflows/examples.yml`.
 
 Example builds are validated by `.github/workflows/examples.yml` across the
 same OS matrix.
@@ -294,7 +294,7 @@ Follows [Conventional Commits](https://www.conventionalcommits.org/).
 |----------|---------|-------------|
 | `examples.yml` | push, PR | Builds all 21 examples × {ubuntu, macos, windows} |
 | `tests.yml` | push, PR | Python pytest × {ubuntu, macos, windows} × Python {3.10, 3.11, 3.12} |
-| `tests.yml` | push, PR | C unit tests (CMake/ctest, 46 tests, ubuntu-latest) |
+| `examples.yml` | push, PR | C unit tests (CMake/ctest, 50 tests, ubuntu-latest) |
 | `release.yml` | tag push | Publishes platform package |
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,11 @@ platform-linux_arm/
 ├── scripts/                 # Setup scripts (setup-mraa-cross.sh, setup-lgpio-cross.sh, …)
 ├── tests/                   # Python unit tests (pytest) for builder scripts
 │                            #   and C unit tests (CMake/ctest) for framework C code
-│   └── stubs/               # C sysfs stubs for link-seam unit testing
+│   ├── test_platform.py     # pytest: builder script unit tests (83 tests)
+│   ├── test_pwm_hal.c       # ctest: PWM HAL C unit tests (29 tests, no hardware needed)
+│   └── stubs/
+│       ├── pwm-hal-sysfs-stub.c  # Link-seam stub — replaces /sys/class/pwm/ with in-memory table
+│       └── pwm-hal-sysfs-stub.h  # Stub control API (stub_reset, stub_set_pi5, stub_set_export_delay)
 └── docs/                    # Documentation (boards, frameworks, security, upload, etc.)
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   first use of GPIO 18/19 (closes #119, reported and diagnosed by
   [@obrain17](https://github.com/obrain17))
 
+### Added
+- lgpio PWM HAL: sysfs seam extraction — `pwm-hal-sysfs.c` and `pwm-hal-internal.h`
+  isolate all `/sys/class/pwm` I/O behind a link-seam interface, enabling native unit
+  testing without Raspberry Pi hardware
+- lgpio PWM HAL: `tests/stubs/pwm-hal-sysfs-stub.c` — link-seam stub that replaces the
+  production sysfs implementation in test builds; tracks export state in-memory
+- lgpio PWM HAL: `tests/test_pwm_hal.c` — 42 C unit tests covering init/deinit, conflict
+  detection, pin validation, frequency/polarity setters, status query, boundary values,
+  and export timeout simulation
+- CI: `cpp-tests` job in `examples.yml` builds and runs the PWM HAL C test suite on
+  ubuntu-latest via CMake + ctest
+- `.pylintrc` — project-specific pylint configuration enforced in CI lint job
+
+### Changed
+- lgpio PWM HAL: `pwm-hal.c` sysfs I/O delegated to the seam; `usleep()` replaced by
+  `pwm_sysfs_sleep_ms()` seam call so unit tests run without real delays
+- CI: `tests.yml` lint job now enforces `pylint` (with `.pylintrc`) and `mypy` across
+  all four Python modules; `fix/**` branches added to push triggers
+- CI: `examples.yml` build matrix extended with `lgpio-pwm-fade` and `lgpio-pwm-servo`;
+  `fix/**` branches added to push triggers
+
 ## [1.9.0] - 2026-04-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   testing without Raspberry Pi hardware
 - lgpio PWM HAL: `tests/stubs/pwm-hal-sysfs-stub.c` — link-seam stub that replaces the
   production sysfs implementation in test builds; tracks export state in-memory
-- lgpio PWM HAL: `tests/test_pwm_hal.c` — 42 C unit tests covering init/deinit, conflict
+- lgpio PWM HAL: `tests/test_pwm_hal.c` — 50 C unit tests covering init/deinit, conflict
   detection, pin validation, frequency/polarity setters, status query, boundary values,
   and export timeout simulation
 - CI: `cpp-tests` job in `examples.yml` builds and runs the PWM HAL C test suite on

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,4 +55,25 @@ target_include_directories(test_pwm_hal PRIVATE
 target_compile_definitions(test_pwm_hal PRIVATE
     UNIT_TESTING=1)
 
+# Safety-oriented warning flags for the C unit test target.
+# -Wall/-Wextra: comprehensive baseline (implicit conversions, sign compare, etc.)
+# -Wshadow: catches variable declarations that shadow outer-scope variables
+# -Wformat=2: format-string security (bounds, type mismatches, non-literal formats)
+# -Wnull-dereference: flags paths that provably dereference NULL
+# -Wvla: bans variable-length arrays (stack-size unpredictability, security risk)
+# -Wstrict-prototypes: requires all function declarations to name parameter types
+# -Wdouble-promotion: flags implicit float→double promotions (precision surprises)
+# -Wswitch-default: every switch must have a default arm (catches unhandled enums)
+target_compile_options(test_pwm_hal PRIVATE
+    -Wall
+    -Wextra
+    -Wshadow
+    -Wformat=2
+    -Wnull-dereference
+    -Wvla
+    -Wstrict-prototypes
+    -Wdouble-promotion
+    -Wswitch-default
+    -Werror)
+
 add_test(NAME test_pwm_hal COMMAND test_pwm_hal)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(arduino_bridge_tests CXX)
+project(platform_linux_arm_tests C CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -38,3 +38,21 @@ target_link_libraries(test_arduino_bridge PRIVATE
 
 enable_testing()
 add_test(NAME test_arduino_bridge COMMAND test_arduino_bridge)
+
+# C unit tests — pwm-hal with sysfs stub (no hardware required)
+# Links pwm-hal.c + stub; does NOT link pwm-hal-sysfs.c (the real sysfs impl).
+# -DUNIT_TESTING=1 enables pwm_reset_state_for_testing() in pwm-hal.c.
+add_executable(test_pwm_hal
+    tests/test_pwm_hal.c
+    framework-lgpio/pwm-hal.c
+    tests/stubs/pwm-hal-sysfs-stub.c)
+
+target_include_directories(test_pwm_hal PRIVATE
+    framework-lgpio
+    tests/stubs
+    tests)
+
+target_compile_definitions(test_pwm_hal PRIVATE
+    UNIT_TESTING=1)
+
+add_test(NAME test_pwm_hal COMMAND test_pwm_hal)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ INSTALL_DIR=$HOME/.local/aarch64-linux-gnu \
 ./scripts/setup-lgpio-cross.sh
 ```
 
-### 5. Set Up MRAA for Cross-Compilation (arduino-bridge, Optional)
+### 6. Set Up MRAA for Cross-Compilation (arduino-bridge, Optional)
 
 If you plan to test or develop the `arduino-bridge` framework examples:
 
@@ -349,7 +349,7 @@ Our GitHub Actions CI automatically tests:
 - Cross-compilation on Ubuntu (Linux x86_64)
 - `baremetal-hello` example for multiple boards
 - `lgpio-blink` example for multiple boards (32-bit and 64-bit)
-- PWM HAL C unit tests (29 tests via CMake/ctest)
+- PWM HAL C unit tests (42 test functions via CMake/ctest)
 
 Make sure your changes pass CI before submitting a PR.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -349,7 +349,7 @@ Our GitHub Actions CI automatically tests:
 - Cross-compilation on Ubuntu (Linux x86_64)
 - `baremetal-hello` example for multiple boards
 - `lgpio-blink` example for multiple boards (32-bit and 64-bit)
-- PWM HAL C unit tests (42 test functions via CMake/ctest)
+- PWM HAL C unit tests (50 test functions via CMake/ctest)
 
 Make sure your changes pass CI before submitting a PR.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,6 +317,31 @@ If you have Raspberry Pi hardware:
    - No runtime errors
    - Expected behavior observed
 
+### C Unit Tests (Required when modifying `framework-lgpio/`)
+
+The PWM HAL has a self-contained C unit test suite that runs without hardware:
+
+```bash
+# Configure
+cmake -B build -DCMAKE_BUILD_TYPE=Debug
+
+# Build and run
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+Tests live in `tests/test_pwm_hal.c`. The suite uses a link-seam stub
+(`tests/stubs/pwm-hal-sysfs-stub.c`) that replaces all filesystem access
+with an in-memory table — no Raspberry Pi hardware required. See
+`docs/TESTING.md` for the full architecture.
+
+**Run these tests if you touch:**
+
+- `framework-lgpio/pwm-hal.c`
+- `framework-lgpio/pwm-hal-sysfs.c`
+- `framework-lgpio/pwm-hal-internal.h`
+- `framework-lgpio/pwm-hal.h`
+
 ### CI/CD Testing
 
 Our GitHub Actions CI automatically tests:
@@ -324,6 +349,7 @@ Our GitHub Actions CI automatically tests:
 - Cross-compilation on Ubuntu (Linux x86_64)
 - `baremetal-hello` example for multiple boards
 - `lgpio-blink` example for multiple boards (32-bit and 64-bit)
+- PWM HAL C unit tests (29 tests via CMake/ctest)
 
 Make sure your changes pass CI before submitting a PR.
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -429,29 +429,39 @@ This project uses semantic versioning (SemVer):
 ```text
 platform-linux_arm/
 ├── .github/
-│   └── workflows/         # CI/CD workflows
-│       ├── examples.yml   # Integration tests
-│       ├── tests.yml      # Unit tests
-│       └── release.yml    # Release automation
-├── boards/                # Board definitions (JSON)
-├── builder/               # SCons build scripts
-│   ├── frameworks/        # Framework integration
-│   └── main.py           # Main build script
-├── docs/                  # Documentation
-├── examples/              # Example projects
-├── tests/                 # Unit tests
-│   ├── conftest.py       # Shared fixtures
-│   ├── test_platform.py  # Platform tests
-│   ├── test_ssh_utils.py # SSH utilities tests
-│   └── test_platform_config.py  # Config tests
-├── platform.py            # Main platform class
-├── platform_config.py     # Configuration support
-├── platform_constants.py  # Constants definitions
-├── ssh_utils.py           # SSH utilities
-├── platform.json          # Platform manifest
-├── pytest.ini             # Pytest configuration
-├── .coveragerc            # Coverage configuration
-└── requirements-dev.txt   # Development dependencies
+│   └── workflows/              # CI/CD workflows
+│       ├── examples.yml        # Integration tests (example builds)
+│       ├── tests.yml           # Unit tests (Python + C)
+│       └── release.yml         # Release automation
+├── boards/                     # Board definitions (JSON)
+├── builder/                    # SCons build scripts
+│   ├── frameworks/             # Framework integration
+│   └── main.py                 # Main build script
+├── docs/                       # Documentation
+├── examples/                   # Example projects
+├── framework-lgpio/            # lgpio framework C sources
+│   ├── pwm-hal.h               # PWM HAL public API
+│   ├── pwm-hal.c               # PWM HAL implementation
+│   ├── pwm-hal-internal.h      # Internal types and sysfs seam declarations
+│   └── pwm-hal-sysfs.c         # Production sysfs seam implementation
+├── tests/                      # Unit tests
+│   ├── stubs/                  # C link-seam stubs (replace sysfs in test builds)
+│   │   ├── pwm-hal-sysfs-stub.c   # Sysfs seam stub implementation
+│   │   └── pwm-hal-sysfs-stub.h   # Stub control interface
+│   ├── conftest.py             # Shared pytest fixtures
+│   ├── test_platform.py        # Platform tests
+│   ├── test_ssh_utils.py       # SSH utilities tests
+│   ├── test_platform_config.py # Config tests
+│   └── test_pwm_hal.c          # PWM HAL C unit tests (CMake/ctest)
+├── platform.py                 # Main platform class
+├── platform_config.py          # Configuration support
+├── platform_constants.py       # Constants definitions
+├── ssh_utils.py                # SSH utilities
+├── platform.json               # Platform manifest
+├── CMakeLists.txt              # CMake build for C unit tests
+├── pytest.ini                  # Pytest configuration
+├── .coveragerc                 # Coverage configuration
+└── requirements-dev.txt        # Development dependencies
 ```
 
 ---
@@ -527,5 +537,5 @@ mypy platform.py
 
 ---
 
-**Document Version**: 1.0
-**Last Updated**: 2025-11-15
+**Document Version**: 1.1
+**Last Updated**: 2026-04-12

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -23,17 +23,20 @@ This document provides guidance for developers working on the platform-linux_arm
 ### Installation
 
 1. Clone the repository:
+
    ```bash
    git clone https://github.com/platformio/platform-linux_arm.git
    cd platform-linux_arm
    ```
 
 2. Install development dependencies:
+
    ```bash
    pip install -r requirements-dev.txt
    ```
 
 3. Install the platform in development mode (symlink):
+
    ```bash
    pio pkg install --global --platform symlink://.
    ```
@@ -49,44 +52,74 @@ The project uses pytest for unit testing. Tests are located in the `tests/` dire
 #### Quick Start
 
 Run all tests:
+
 ```bash
 pytest
 ```
 
 Run with verbose output:
+
 ```bash
 pytest -v
 ```
 
 Run specific test file:
+
 ```bash
 pytest tests/test_platform.py -v
 ```
 
 Run specific test class:
+
 ```bash
 pytest tests/test_platform.py::TestIsNative -v
 ```
 
 Run specific test method:
+
 ```bash
 pytest tests/test_platform.py::TestIsNative::test_is_native_on_linux_arm -v
 ```
 
+### C Unit Tests (CMake)
+
+The `framework-lgpio/pwm-hal` C library has a native unit test suite that does not require Raspberry Pi hardware.
+
+Build and run:
+
+```bash
+cmake -B build
+cmake --build build --target test_pwm_hal
+./build/test_pwm_hal
+```
+
+Or run via ctest:
+
+```bash
+cmake -B build && cmake --build build
+ctest --test-dir build
+```
+
+The tests use a link-seam stub (`tests/stubs/pwm-hal-sysfs-stub.c`) that replaces the production sysfs
+implementation, so no `/sys/class/pwm` access is needed.
+
 #### Coverage Reports
 
 Generate coverage report:
+
 ```bash
 pytest --cov=. --cov-report=term-missing
 ```
 
 Generate HTML coverage report:
+
 ```bash
 pytest --cov=. --cov-report=html
 # Open htmlcov/index.html in your browser
 ```
 
 Generate XML coverage report (for CI):
+
 ```bash
 pytest --cov=. --cov-report=xml
 ```
@@ -186,6 +219,7 @@ pylint *.py
 3. **Test Class Naming**: Test classes should match the pattern `Test*`
 
 4. **Test Structure**: Follow the Arrange-Act-Assert pattern
+
    ```python
    def test_example():
        # Arrange - Set up test data and mocks
@@ -199,6 +233,7 @@ pylint *.py
    ```
 
 5. **Use Fixtures**: Leverage pytest fixtures from `tests/conftest.py` for common setup:
+
    ```python
    def test_with_fixture(mock_env, temp_project_dir):
        # Use fixtures directly as function parameters
@@ -206,6 +241,7 @@ pylint *.py
    ```
 
 6. **Mock External Dependencies**: Use `unittest.mock` to isolate units:
+
    ```python
    @patch('platform.get_systype')
    def test_with_mock(mock_get_systype):
@@ -214,6 +250,7 @@ pylint *.py
    ```
 
 7. **Test Edge Cases**: Include tests for error conditions and boundary cases
+
    ```python
    def test_invalid_input_raises_error():
        with pytest.raises(ValueError, match="expected error message"):
@@ -234,6 +271,7 @@ pylint *.py
 ### Continuous Integration
 
 Tests run automatically on GitHub Actions for:
+
 - Every push to `develop` and `main` branches
 - Every pull request
 
@@ -257,7 +295,7 @@ This project uses git-flow:
 
 Follow conventional commit format:
 
-```
+```text
 <type>(<scope>): <subject>
 
 <body>
@@ -266,6 +304,7 @@ Follow conventional commit format:
 ```
 
 **Types**:
+
 - `feat`: New feature
 - `fix`: Bug fix
 - `docs`: Documentation changes
@@ -275,6 +314,7 @@ Follow conventional commit format:
 - `chore`: Maintenance tasks
 
 **Examples**:
+
 ```bash
 feat(platform): add support for Raspberry Pi 5
 fix(upload): handle timeout errors gracefully
@@ -285,6 +325,7 @@ test(platform): improve coverage for _is_native method
 ### Pull Request Process
 
 1. Create a feature branch from `develop`:
+
    ```bash
    git checkout develop
    git pull
@@ -292,6 +333,7 @@ test(platform): improve coverage for _is_native method
    ```
 
 2. Make your changes and add tests:
+
    ```bash
    # Make changes
    # Add tests
@@ -299,18 +341,21 @@ test(platform): improve coverage for _is_native method
    ```
 
 3. Format and lint your code:
+
    ```bash
    black .
    isort .
    ```
 
 4. Commit your changes:
+
    ```bash
    git add .
    git commit -m "feat(scope): description"
    ```
 
 5. Push and create pull request:
+
    ```bash
    git push origin feature/your-feature-name
    # Create PR on GitHub targeting 'develop' branch
@@ -325,6 +370,7 @@ test(platform): improve coverage for _is_native method
 ### Version Numbering
 
 This project uses semantic versioning (SemVer):
+
 - **Major** (1.x.x): Breaking changes
 - **Minor** (x.1.x): New features (backward compatible)
 - **Patch** (x.x.1): Bug fixes (backward compatible)
@@ -332,6 +378,7 @@ This project uses semantic versioning (SemVer):
 ### Release Checklist
 
 1. **Update Version**:
+
    ```json
    // platform.json
    {
@@ -342,11 +389,13 @@ This project uses semantic versioning (SemVer):
 2. **Update Changelog**: Document all changes since last release
 
 3. **Run Full Test Suite**:
+
    ```bash
    pytest
    ```
 
 4. **Create Release Branch**:
+
    ```bash
    git checkout develop
    git checkout -b release/v1.7.0
@@ -355,6 +404,7 @@ This project uses semantic versioning (SemVer):
 5. **Final Testing**: Verify all examples build successfully
 
 6. **Merge to Main**:
+
    ```bash
    git checkout main
    git merge --no-ff release/v1.7.0
@@ -363,6 +413,7 @@ This project uses semantic versioning (SemVer):
    ```
 
 7. **Merge Back to Develop**:
+
    ```bash
    git checkout develop
    git merge --no-ff release/v1.7.0
@@ -375,7 +426,7 @@ This project uses semantic versioning (SemVer):
 
 ## Project Structure
 
-```
+```text
 platform-linux_arm/
 ├── .github/
 │   └── workflows/         # CI/CD workflows
@@ -424,7 +475,7 @@ pio run --target clean
 pio run --target upload
 ```
 
-### Testing
+### Testing Commands
 
 ```bash
 # Run all tests
@@ -440,7 +491,7 @@ pytest tests/test_platform.py
 ptw
 ```
 
-### Code Quality
+### Quality Commands
 
 ```bash
 # Format code
@@ -460,19 +511,19 @@ mypy platform.py
 
 ## Resources
 
-- **PlatformIO Documentation**: https://docs.platformio.org/
-- **PlatformIO Platform Development**: https://docs.platformio.org/en/latest/platforms/creating_platform.html
-- **pytest Documentation**: https://docs.pytest.org/
-- **Black Formatter**: https://black.readthedocs.io/
-- **Conventional Commits**: https://www.conventionalcommits.org/
+- **PlatformIO Documentation**: <https://docs.platformio.org/>
+- **PlatformIO Platform Development**: <https://docs.platformio.org/en/latest/platforms/creating_platform.html>
+- **pytest Documentation**: <https://docs.pytest.org/>
+- **Black Formatter**: <https://black.readthedocs.io/>
+- **Conventional Commits**: <https://www.conventionalcommits.org/>
 
 ---
 
 ## Getting Help
 
-- **Issues**: https://github.com/platformio/platform-linux_arm/issues
-- **Discussions**: https://github.com/platformio/platform-linux_arm/discussions
-- **Wiki**: https://github.com/platformio/platform-linux_arm/wiki
+- **Issues**: <https://github.com/platformio/platform-linux_arm/issues>
+- **Discussions**: <https://github.com/platformio/platform-linux_arm/discussions>
+- **Wiki**: <https://github.com/platformio/platform-linux_arm/wiki>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 
 [![Examples](https://github.com/sfo2001/platform-linux_arm/actions/workflows/examples.yml/badge.svg)](https://github.com/sfo2001/platform-linux_arm/actions/workflows/examples.yml)
 
-> This is an actively maintained fork of the official [platformio/platform-linux_arm](https://github.com/platformio/platform-linux_arm) platform (last updated May 2022). Adds Raspberry Pi 5 support, lgpio framework, remote development workflows, and additional examples. See [CHANGELOG.md](CHANGELOG.md) for details.
+> This is an actively maintained fork of the official
+> [platformio/platform-linux_arm](https://github.com/platformio/platform-linux_arm) platform
+> (last updated May 2022). Adds Raspberry Pi 5 support, lgpio framework, remote development
+> workflows, and additional examples. See [CHANGELOG.md](CHANGELOG.md) for details.
 
-Linux ARM platform enables building native applications for ARM-based Linux systems (Raspberry Pi, Orange Pi, etc.) using PlatformIO Core 6.0+. Supports both cross-compilation from your development machine and native compilation on ARM devices.
+Linux ARM platform enables building native applications for ARM-based Linux systems
+(Raspberry Pi, Orange Pi, etc.) using PlatformIO Core 6.0+. Supports both
+cross-compilation from your development machine and native compilation on ARM devices.
 
 ## Key Features
 
@@ -27,13 +32,17 @@ Linux ARM platform enables building native applications for ARM-based Linux syst
 - [Troubleshooting](docs/TROUBLESHOOTING.md) - Common issues and solutions
 - [Contributing](CONTRIBUTING.md) - How to contribute
 
-> **Note for VS Code users:** The PlatformIO GUI's "Monitor" button is for serial ports only and does not work with this platform. For SSH monitoring support, copy [examples/vscode/tasks.json](examples/vscode/tasks.json) to your project's `.vscode/` folder. See [docs/VSCODE.md](docs/VSCODE.md) for details.
+> **Note for VS Code users:** The PlatformIO GUI's "Monitor" button is for serial ports only
+> and does not work with this platform. For SSH monitoring support, copy
+> [examples/vscode/tasks.json](examples/vscode/tasks.json) to your project's `.vscode/` folder.
+> See [docs/VSCODE.md](docs/VSCODE.md) for details.
 
 ## Installation
 
 ### 1. Install PlatformIO
 
 If you haven't already:
+
 ```bash
 pip install -U platformio
 ```
@@ -45,11 +54,13 @@ Or install [PlatformIO IDE](https://platformio.org/install/ide) for VS Code, CLi
 Choose based on your development machine:
 
 **Linux (x86_64):**
+
 ```bash
 sudo apt install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
 ```
 
 **macOS (Intel or Apple Silicon):**
+
 ```bash
 brew tap messense/macos-cross-toolchains
 brew install arm-unknown-linux-gnueabihf
@@ -77,6 +88,7 @@ upload_port = pi@raspberrypi.local:/home/pi/myapp
 ```
 
 Or use a stable release:
+
 ```ini
 platform = linux_arm@^1.8.0
 ```
@@ -111,9 +123,11 @@ int main(void) {
 ```
 
 See `examples/` directory for more:
+
 - `lgpio-blink/` - Basic GPIO control
 - `lgpio-i2c-sensor/` - I2C sensor reading (BME280)
 - `lgpio-pwm-fade/` - Hardware PWM LED fading
+- `lgpio-pwm-servo/` - Hardware PWM servo control
 - `lgpio-spi-adc/` - SPI communication (MCP3008)
 - `baremetal-threads/` - Multi-threading with POSIX threads
 - `remote-deployment/` - Automated deployment example
@@ -129,6 +143,7 @@ This platform uses SSH for remote operations (upload, test, debug). Review secur
 - Host Verification: Enable strict host key checking in production environments
 
 Quick Security Checklist:
+
 - [ ] Using dedicated SSH key (not personal key)
 - [ ] SSH key permissions set to 600 (`chmod 600 ~/.ssh/key`)
 - [ ] Host key verification enabled for production
@@ -138,6 +153,7 @@ Quick Security Checklist:
 For detailed security configuration, see [SECURITY.md](SECURITY.md).
 
 Recent Security Improvements (v1.7.1):
+
 - Fixed command injection vulnerabilities (CVSS 8.0-9.0)
 - Added timeout protection against DoS attacks
 - Added security documentation
@@ -201,11 +217,13 @@ See [docs/FRAMEWORKS.md](docs/FRAMEWORKS.md) for detailed comparison.
 ## Building and Deploying
 
 ### Build Locally
+
 ```bash
 pio run
 ```
 
 ### Upload to Remote Device
+
 ```bash
 pio run --target upload
 ```
@@ -213,6 +231,7 @@ pio run --target upload
 Requires `upload_protocol` configuration - see [docs/UPLOAD.md](docs/UPLOAD.md).
 
 ### Run Tests on Hardware
+
 ```bash
 pio test
 ```
@@ -220,6 +239,7 @@ pio test
 Requires `test_transport = ssh` - see [docs/TESTING.md](docs/TESTING.md).
 
 ### Debug Remotely
+
 ```bash
 pio debug
 ```
@@ -241,6 +261,7 @@ board_build.arch = aarch64
 ```
 
 Requires 64-bit toolchain:
+
 ```bash
 # Linux
 sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
@@ -275,7 +296,7 @@ See [Platform Documentation](docs/platforms/linux_arm.rst) for all configuration
 
 ## Project Structure
 
-```
+```text
 your-project/
 ├── platformio.ini        # Project configuration
 ├── src/

--- a/builder/frameworks/lgpio.py
+++ b/builder/frameworks/lgpio.py
@@ -150,6 +150,8 @@ env.Append(
     LIBS=["lgpio"],
 )
 
-# Build PWM HAL library
+# Build PWM HAL library — compiles all .c files in framework-lgpio/ (currently
+# pwm-hal.c and pwm-hal-sysfs.c). Any new .c file added to that directory is
+# automatically included in every lgpio production build.
 pwm_hal_src = join(env.PioPlatform().get_dir(), "framework-lgpio")
 env.BuildSources(join("$BUILD_DIR", "FrameworkLgpioPwmHAL"), pwm_hal_src)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,7 +4,8 @@
 **Platform Version**: 1.8.0
 **CI/CD Status**: [![Examples](https://github.com/sfo2001/platform-linux_arm/actions/workflows/examples.yml/badge.svg)](https://github.com/sfo2001/platform-linux_arm/actions/workflows/examples.yml)
 
-This document provides a comprehensive testing matrix for the platform-linux_arm platform, covering all supported boards, frameworks, architectures, and build configurations.
+This document provides a comprehensive testing matrix for the platform-linux_arm platform, covering all
+supported boards, frameworks, architectures, and build configurations.
 
 ## Table of Contents
 
@@ -47,6 +48,7 @@ This document provides a comprehensive testing matrix for the platform-linux_arm
 ### CI Build Process
 
 1. **Toolchain Installation**: Both ARM 32-bit and 64-bit cross-compilers
+
    ```bash
    gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf  # 32-bit
    gcc-aarch64-linux-gnu g++-aarch64-linux-gnu      # 64-bit
@@ -57,6 +59,7 @@ This document provides a comprehensive testing matrix for the platform-linux_arm
    - 64-bit: `CROSS_PREFIX=aarch64-linux-gnu- ./scripts/setup-lgpio-cross.sh`
 
 3. **Platform Installation**: Symlink mode for testing
+
    ```bash
    pio pkg install --global --platform symlink://.
    ```
@@ -65,9 +68,60 @@ This document provides a comprehensive testing matrix for the platform-linux_arm
 
 ---
 
+## C Unit Tests (CMake)
+
+The `framework-lgpio/pwm-hal` library has a self-contained C unit test suite that runs without Raspberry Pi hardware.
+
+### Overview
+
+| Property | Value |
+|----------|-------|
+| Test file | `tests/test_pwm_hal.c` |
+| Test target | `test_pwm_hal` |
+| Build system | CMake (out-of-source) |
+| Hardware required | None |
+| Tests | 20 unit tests |
+
+### Architecture
+
+The tests use a **link-seam** architecture:
+
+- Production builds link `framework-lgpio/pwm-hal.c` + `framework-lgpio/pwm-hal-sysfs.c`
+- Test builds link `framework-lgpio/pwm-hal.c` + `tests/stubs/pwm-hal-sysfs-stub.c`
+
+The stub replaces all filesystem access (`/sys/class/pwm/...`) with an in-memory table,
+making tests fast, deterministic, and hardware-independent.
+
+The seam interface is defined in `framework-lgpio/pwm-hal-internal.h`.
+
+### Building and Running
+
+```bash
+# Configure and build
+cmake -B build
+cmake --build build --target test_pwm_hal
+
+# Run directly
+./build/test_pwm_hal
+
+# Or via ctest
+ctest --test-dir build
+```
+
+### Adding New Tests
+
+1. Add a new `static void test_your_test(void)` function to `tests/test_pwm_hal.c`
+2. Call `stub_reset()` and `pwm_reset_state_for_testing()` at the start
+3. Add `RUN(test_your_test)` in `main()`
+4. Update the final `printf("All N tests passed.\n")` count
+5. If the test needs new stub behavior, extend `tests/stubs/pwm-hal-sysfs-stub.h/.c`
+
+---
+
 ## Board × Framework Compatibility Matrix
 
 ### Legend
+
 - Yes - Fully Supported: Tested and working
 - Partial - Limited Support: Works with known limitations
 - No - Not Supported: Framework incompatible with board
@@ -88,6 +142,7 @@ This document provides a comprehensive testing matrix for the platform-linux_arm
 | **Raspberry Pi Zero 2W** | Yes | Deprecated | Deprecated | Yes |
 
 **Notes:**
+
 - \* **Pi 1 / Zero (original)**: Requires `RPI_LGPIO_REVISION` environment variable for lgpio
 - \*\* **Pi 5 wiringpi**: GCLK (general purpose clock) function not supported due to RP1 chip limitations
 
@@ -133,6 +188,7 @@ board_build.arch = aarch64
 ```
 
 **Requirements:**
+
 - 64-bit Raspberry Pi OS on target device
 - 64-bit cross-compilation toolchain: `gcc-aarch64-linux-gnu`
 - 64-bit libraries for frameworks (e.g., `liblgpio-dev:arm64`)
@@ -152,12 +208,14 @@ board_build.arch = aarch64
 | **ARM Linux (Native)** | Yes | Yes | System GCC (no cross-compiler needed) | Manually tested |
 
 **Legend:**
+
 - Yes - = Tested and verified working
 - Partial - = Code exists, toolchains available, but not tested in practice
 
 ### Native Compilation (On Raspberry Pi)
 
-When running PlatformIO directly on a Raspberry Pi, the platform automatically detects the native environment and uses the system GCC compiler.
+When running PlatformIO directly on a Raspberry Pi, the platform automatically detects the native
+environment and uses the system GCC compiler.
 
 | Raspberry Pi OS | Compiler | Notes |
 |-----------------|----------|-------|
@@ -249,6 +307,7 @@ framework = lgpio
 **Reason**: RP1 chip documentation doesn't provide clock control details needed for implementation.
 
 **Affected Functions**:
+
 - `gpioClockSet()`
 - Clock-based PWM on certain pins
 
@@ -263,6 +322,7 @@ framework = lgpio
 **Reason**: WiringPi build system not configured for cross-compilation.
 
 **Workaround**:
+
 - Build on physical Raspberry Pi device
 - OR use lgpio/pigpio (support cross-compilation)
 
@@ -308,6 +368,7 @@ ExecStart=/path/to/program
 **Reason**: No package manager like apt/homebrew on Windows.
 
 **Workaround**:
+
 1. Download from [ARM Developer website](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 2. Add to PATH manually
 
@@ -326,6 +387,7 @@ ExecStart=/path/to/program
 **Solution**: Build libraries from source for 64-bit target.
 
 **Example** (lgpio 64-bit):
+
 ```bash
 CROSS_PREFIX=aarch64-linux-gnu- \
 INSTALL_DIR=$HOME/.local/aarch64-linux-gnu \
@@ -337,6 +399,7 @@ INSTALL_DIR=$HOME/.local/aarch64-linux-gnu \
 **Issue**: 64-bit binaries require 64-bit Raspberry Pi OS on target device.
 
 **Verification**:
+
 ```bash
 # On Raspberry Pi
 uname -m
@@ -357,6 +420,7 @@ uname -m
 4. **Toolchain Validation**: Both ARM toolchains installed and working
 
 **Limitations**:
+
 - CI only runs on Ubuntu (Linux x86_64) - macOS and Windows untested
 - No runtime testing (no physical hardware in CI)
 - No pigpio/wiringpi testing (deprecated/native-only)
@@ -367,16 +431,19 @@ uname -m
 #### Test Procedure
 
 1. **Build on host system** (cross-compilation):
+
    ```bash
    pio run -e raspberrypi_4b
    ```
 
 2. **Transfer to Raspberry Pi**:
+
    ```bash
    scp .pio/build/raspberrypi_4b/program pi@raspberrypi.local:~
    ```
 
 3. **Run on Raspberry Pi**:
+
    ```bash
    ssh pi@raspberrypi.local
    chmod +x program
@@ -391,6 +458,7 @@ uname -m
 #### Test Hardware
 
 Testing has been performed on:
+
 - Yes - Raspberry Pi 3 Model B (32-bit and 64-bit OS)
 - Yes - Raspberry Pi 4 Model B (32-bit and 64-bit OS)
 - Yes - Raspberry Pi 5 (64-bit OS)
@@ -399,6 +467,7 @@ Testing has been performed on:
 ### Community Testing
 
 We welcome community testing reports! Please open an issue with:
+
 - Board model and OS version
 - Framework and architecture
 - Build host OS

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -80,7 +80,7 @@ The `framework-lgpio/pwm-hal` library has a self-contained C unit test suite tha
 | Test target | `test_pwm_hal` |
 | Build system | CMake (out-of-source) |
 | Hardware required | None |
-| Tests | 42 unit tests |
+| Tests | 50 unit tests |
 
 ### Architecture
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -80,7 +80,7 @@ The `framework-lgpio/pwm-hal` library has a self-contained C unit test suite tha
 | Test target | `test_pwm_hal` |
 | Build system | CMake (out-of-source) |
 | Hardware required | None |
-| Tests | 20 unit tests |
+| Tests | 29 unit tests |
 
 ### Architecture
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,7 +1,7 @@
 # Platform Testing Matrix
 
-**Last Updated**: 2025-11-30
-**Platform Version**: 1.8.0
+**Last Updated**: 2026-04-12
+**Platform Version**: 1.9.x
 **CI/CD Status**: [![Examples](https://github.com/sfo2001/platform-linux_arm/actions/workflows/examples.yml/badge.svg)](https://github.com/sfo2001/platform-linux_arm/actions/workflows/examples.yml)
 
 This document provides a comprehensive testing matrix for the platform-linux_arm platform, covering all
@@ -80,7 +80,7 @@ The `framework-lgpio/pwm-hal` library has a self-contained C unit test suite tha
 | Test target | `test_pwm_hal` |
 | Build system | CMake (out-of-source) |
 | Hardware required | None |
-| Tests | 29 unit tests |
+| Tests | 42 unit tests |
 
 ### Architecture
 
@@ -545,7 +545,7 @@ We welcome community testing reports! Please open an issue with:
 ---
 
 **Document Version**: 1.0
-**Last Updated**: 2025-11-09
+**Last Updated**: 2026-04-12
 **Maintained By**: platform-linux_arm Team
 
 For questions or to report testing results, please open an issue on [GitHub](https://github.com/platformio/platform-linux_arm/issues).

--- a/examples/lgpio-pwm-fade/src/pwm_fade.c
+++ b/examples/lgpio-pwm-fade/src/pwm_fade.c
@@ -132,10 +132,22 @@ int main(int argc, char *argv[]) {
 
     // Parse command line arguments
     if (argc > 1) {
-        gpio_pin = atoi(argv[1]);
+        char *end;
+        long val = strtol(argv[1], &end, 10);
+        if (*end != '\0' || val < 0 || val > 99) {
+            fprintf(stderr, "Invalid GPIO pin: %s\n", argv[1]);
+            return 1;
+        }
+        gpio_pin = (int)val;
     }
     if (argc > 2) {
-        frequency = atoi(argv[2]);
+        char *end;
+        long val = strtol(argv[2], &end, 10);
+        if (*end != '\0' || val < PWM_MIN_FREQUENCY_HZ || val > PWM_MAX_FREQUENCY_HZ) {
+            fprintf(stderr, "Invalid frequency: %s\n", argv[2]);
+            return 1;
+        }
+        frequency = (int)val;
     }
 
     // Print header

--- a/examples/lgpio-pwm-servo/src/servo_control.c
+++ b/examples/lgpio-pwm-servo/src/servo_control.c
@@ -250,7 +250,13 @@ int main(int argc, char *argv[]) {
 
     // Parse command line arguments
     if (argc > 1) {
-        gpio_pin = atoi(argv[1]);
+        char *end;
+        long val = strtol(argv[1], &end, 10);
+        if (*end != '\0' || val < 0 || val > 99) {
+            fprintf(stderr, "Invalid GPIO pin: %s\n", argv[1]);
+            return 1;
+        }
+        gpio_pin = (int)val;
     }
 
     // Print header

--- a/framework-lgpio/pwm-hal-internal.h
+++ b/framework-lgpio/pwm-hal-internal.h
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * pwm-hal-internal.h — Internal types and sysfs seam declarations for pwm-hal.
+ *
+ * This header is included by:
+ *   - pwm-hal.c             (uses the seam and the typedef)
+ *   - pwm-hal-sysfs.c       (provides the production implementations)
+ *   - tests/stubs/          (provides the stub implementations)
+ *   - tests/test_pwm_hal.c  (directly accesses pwm_reset_state_for_testing)
+ */
+#ifndef PWM_HAL_INTERNAL_H
+#define PWM_HAL_INTERNAL_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+/* Shared constants used by pwm-hal.c and pwm-hal-sysfs.c */
+#define PWM_SYSFS_BASE "/sys/class/pwm"
+#define MAX_PATH_LEN   256
+
+/**
+ * Number of 10ms polling iterations in pwm_export() before declaring timeout.
+ * Shared with tests/test_pwm_hal.c so T20 (test_export_timeout) stays in sync
+ * with the loop bound — pass exactly PWM_EXPORT_RETRIES to stub_set_export_delay()
+ * to trigger PWM_ERROR_IO reliably.
+ */
+#define PWM_EXPORT_RETRIES  10
+
+/**
+ * @brief GPIO pin to PWM chip/channel mapping
+ *
+ * Moved here from pwm-hal.c so stub and sysfs translation units share the type.
+ */
+typedef struct {
+    int gpio_pin;    /**< GPIO pin number (BCM); -1 = sentinel */
+    int pwm_chip;    /**< PWM chip number */
+    int pwm_channel; /**< PWM channel (0 or 1) */
+} pwm_pin_map_t;
+
+/* GPIO-to-chip/channel pin maps — defined in pwm-hal.c (always linked). */
+/* Both pwm-hal-sysfs.c (production) and stubs reference these. */
+extern const pwm_pin_map_t g_pwm_pin_map_pi1_4[];
+extern const pwm_pin_map_t g_pwm_pin_map_pi5[];
+
+/**
+ * Sysfs seam functions.
+ * Production implementations live in pwm-hal-sysfs.c.
+ * Test stub implementations live in tests/stubs/pwm-hal-sysfs-stub.c.
+ */
+int  pwm_sysfs_write(const char *path, const char *value);
+/* reserved for issue #124 — not yet called from pwm-hal.c */
+int  pwm_sysfs_read(const char *path, char *value, size_t max_len);
+/**
+ * Sleep for the given number of milliseconds.  Production implementation calls
+ * usleep(); the test stub is a no-op so unit tests run without real delays.
+ */
+void pwm_sysfs_sleep_ms(int ms);
+bool pwm_is_exported(int chip, int channel);
+const pwm_pin_map_t *pwm_get_pin_map(void);
+
+/**
+ * Test-only state reset.  Compiled only when -DUNIT_TESTING=1 is set (CMake
+ * test target).  Resets g_pwm_channels and g_pwm_initialized so each test
+ * starts from a clean slate without rebuilding.
+ */
+#ifdef UNIT_TESTING
+void pwm_reset_state_for_testing(void);
+#endif
+
+#endif /* PWM_HAL_INTERNAL_H */

--- a/framework-lgpio/pwm-hal-internal.h
+++ b/framework-lgpio/pwm-hal-internal.h
@@ -49,7 +49,7 @@ extern const pwm_pin_map_t g_pwm_pin_map_pi5[];
  * Test stub implementations live in tests/stubs/pwm-hal-sysfs-stub.c.
  */
 int  pwm_sysfs_write(const char *path, const char *value);
-/* reserved for issue #124 — not yet called from pwm-hal.c */
+/** @todo(#124) Reserved — not yet called from pwm-hal.c */
 int  pwm_sysfs_read(const char *path, char *value, size_t max_len);
 /**
  * Sleep for the given number of milliseconds.  Production implementation calls

--- a/framework-lgpio/pwm-hal-internal.h
+++ b/framework-lgpio/pwm-hal-internal.h
@@ -49,7 +49,13 @@ extern const pwm_pin_map_t g_pwm_pin_map_pi5[];
  * Test stub implementations live in tests/stubs/pwm-hal-sysfs-stub.c.
  */
 int  pwm_sysfs_write(const char *path, const char *value);
-/** @todo(#124) Reserved — not yet called from pwm-hal.c */
+/**
+ * Read a sysfs attribute into value (max_len bytes, NUL-terminated).
+ * @todo(#124) Not yet called from pwm-hal.c — readback support is planned.
+ * Stub and production implementations MUST provide this function regardless,
+ * as it is part of the mandatory seam contract; a stub that omits it will
+ * fail to link when #124 wires up the caller.
+ */
 int  pwm_sysfs_read(const char *path, char *value, size_t max_len);
 /**
  * Sleep for the given number of milliseconds.  Production implementation calls
@@ -66,6 +72,12 @@ const pwm_pin_map_t *pwm_get_pin_map(void);
  */
 #ifdef UNIT_TESTING
 void pwm_reset_state_for_testing(void);
+/**
+ * Fill all state slots with fictional entries to simulate slot exhaustion.
+ * Use before calling pwm_init() to trigger the PWM_ERROR_HARDWARE path in
+ * pwm_alloc_state().  See pwm-hal.c for implementation details.
+ */
+void pwm_fill_channels_for_testing(void);
 #endif
 
 #endif /* PWM_HAL_INTERNAL_H */

--- a/framework-lgpio/pwm-hal-sysfs.c
+++ b/framework-lgpio/pwm-hal-sysfs.c
@@ -55,6 +55,11 @@ int pwm_sysfs_read(const char *path, char *value, size_t max_len) {
         return PWM_ERROR_IO;
     }
 
+    if (max_len == 0) {
+        close(fd);
+        return PWM_ERROR_INVALID_PARAM;
+    }
+
     ssize_t len = read(fd, value, max_len - 1);
     close(fd);
 

--- a/framework-lgpio/pwm-hal-sysfs.c
+++ b/framework-lgpio/pwm-hal-sysfs.c
@@ -27,14 +27,15 @@ int pwm_sysfs_write(const char *path, const char *value) {
         return PWM_ERROR_IO;
     }
 
-    ssize_t len     = (ssize_t)strlen(value);
-    ssize_t written = write(fd, value, (size_t)len);
+    ssize_t len        = (ssize_t)strlen(value);
+    ssize_t written    = write(fd, value, (size_t)len);
+    int     write_errno = errno;   /* capture before close() can clobber */
     close(fd);
 
     if (written != len) {
-        if (errno == EACCES || errno == EPERM)  return PWM_ERROR_PERMISSION;
-        if (errno == EBUSY)                      return PWM_ERROR_BUSY;
-        if (errno == EINVAL)                     return PWM_ERROR_INVALID_PARAM;
+        if (write_errno == EACCES || write_errno == EPERM)  return PWM_ERROR_PERMISSION;
+        if (write_errno == EBUSY)                            return PWM_ERROR_BUSY;
+        if (write_errno == EINVAL)                           return PWM_ERROR_INVALID_PARAM;
         return PWM_ERROR_IO;
     }
 

--- a/framework-lgpio/pwm-hal-sysfs.c
+++ b/framework-lgpio/pwm-hal-sysfs.c
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * pwm-hal-sysfs.c — Production sysfs implementations for pwm-hal seam.
+ *
+ * Linked in production builds.  Replaced by tests/stubs/pwm-hal-sysfs-stub.c
+ * in unit-test builds (CMake target test_pwm_hal sets -DUNIT_TESTING=1 and
+ * links this file out).
+ */
+#include "pwm-hal.h"
+#include "pwm-hal-internal.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
+/* ---- Seam implementations ---- */
+
+int pwm_sysfs_write(const char *path, const char *value) {
+    int fd = open(path, O_WRONLY);
+    if (fd < 0) {
+        if (errno == EACCES || errno == EPERM)  return PWM_ERROR_PERMISSION;
+        if (errno == EBUSY)                      return PWM_ERROR_BUSY;
+        if (errno == ENOENT || errno == ENODEV)  return PWM_ERROR_NOT_EXPORTED;
+        return PWM_ERROR_IO;
+    }
+
+    ssize_t len     = (ssize_t)strlen(value);
+    ssize_t written = write(fd, value, (size_t)len);
+    close(fd);
+
+    if (written != len) {
+        if (errno == EACCES || errno == EPERM)  return PWM_ERROR_PERMISSION;
+        if (errno == EBUSY)                      return PWM_ERROR_BUSY;
+        if (errno == EINVAL)                     return PWM_ERROR_INVALID_PARAM;
+        return PWM_ERROR_IO;
+    }
+
+    return PWM_SUCCESS;
+}
+
+void pwm_sysfs_sleep_ms(int ms) {
+    if (ms <= 0) return;
+    usleep((useconds_t)ms * 1000);
+}
+
+/* TODO(#124): currently dead code — no caller in pwm-hal.c. */
+int pwm_sysfs_read(const char *path, char *value, size_t max_len) {
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        if (errno == EACCES || errno == EPERM)  return PWM_ERROR_PERMISSION;
+        if (errno == ENOENT || errno == ENODEV)  return PWM_ERROR_NOT_EXPORTED;
+        return PWM_ERROR_IO;
+    }
+
+    ssize_t len = read(fd, value, max_len - 1);
+    close(fd);
+
+    if (len < 0) return PWM_ERROR_IO;
+
+    value[len] = '\0';
+    if (len > 0 && value[len - 1] == '\n') value[len - 1] = '\0';
+
+    return PWM_SUCCESS;
+}
+
+bool pwm_is_exported(int chip, int channel) {
+    char path[MAX_PATH_LEN];
+    struct stat st;
+    snprintf(path, sizeof(path), "%s/pwmchip%d/pwm%d", PWM_SYSFS_BASE, chip, channel);
+    return (stat(path, &st) == 0 && S_ISDIR(st.st_mode));
+}
+
+const pwm_pin_map_t *pwm_get_pin_map(void) {
+    /*
+     * Heuristic: pwmchip2 exists on Pi 5 (two PWM controllers) but not on
+     * Pi 1–4 (single controller, pwmchip0 only).  Known limitation: this
+     * detection can produce a false Pi 5 result if pwmchip2 is present for
+     * another reason (e.g. a USB PWM adapter), or a false Pi 1–4 result if
+     * the Pi 5 pwm overlay is not loaded.  Tracked for improvement in #124.
+     */
+    struct stat st;
+    if (stat("/sys/class/pwm/pwmchip2", &st) == 0 && S_ISDIR(st.st_mode)) {
+        return g_pwm_pin_map_pi5;
+    }
+    return g_pwm_pin_map_pi1_4;
+}

--- a/framework-lgpio/pwm-hal-sysfs.c
+++ b/framework-lgpio/pwm-hal-sysfs.c
@@ -46,7 +46,7 @@ void pwm_sysfs_sleep_ms(int ms) {
     usleep((useconds_t)ms * 1000);
 }
 
-/* TODO(#124): currently dead code — no caller in pwm-hal.c. */
+/* @todo(#124): no callers yet — reserved for live readback */
 int pwm_sysfs_read(const char *path, char *value, size_t max_len) {
     int fd = open(path, O_RDONLY);
     if (fd < 0) {

--- a/framework-lgpio/pwm-hal.c
+++ b/framework-lgpio/pwm-hal.c
@@ -360,7 +360,7 @@ int pwm_write(int pin, float duty_cycle_percent) {
 
     // Calculate duty cycle in nanoseconds
     uint64_t period_ns = 1000000000ULL / state->frequency_hz;
-    uint64_t duty_cycle_ns = (uint64_t)(period_ns * (duty_cycle_percent / 100.0f));
+    uint64_t duty_cycle_ns = (uint64_t)((double)period_ns * (duty_cycle_percent / 100.0));
 
     // Set duty cycle
     char path[MAX_PATH_LEN];
@@ -441,7 +441,7 @@ int pwm_set_frequency(int pin, uint32_t freq_hz) {
     }
 
     // Update duty cycle to maintain percentage
-    uint64_t duty_cycle_ns = (uint64_t)(period_ns * (state->duty_cycle_percent / 100.0f));
+    uint64_t duty_cycle_ns = (uint64_t)((double)period_ns * (state->duty_cycle_percent / 100.0));
     snprintf(path, sizeof(path), "%s/pwmchip%d/pwm%d/duty_cycle",
              PWM_SYSFS_BASE, state->pwm_chip, state->pwm_channel);
     snprintf(value, sizeof(value), "%llu", (unsigned long long)duty_cycle_ns);
@@ -544,7 +544,7 @@ int pwm_get_status(int pin, pwm_status_t *status) {
     status->duty_cycle_percent = state->duty_cycle_percent;
     status->polarity = state->polarity;
     status->period_ns = 1000000000ULL / state->frequency_hz;
-    status->duty_cycle_ns = (uint64_t)(status->period_ns * (state->duty_cycle_percent / 100.0f));
+    status->duty_cycle_ns = (uint64_t)((double)status->period_ns * (state->duty_cycle_percent / 100.0));
 
     return PWM_SUCCESS;
 }

--- a/framework-lgpio/pwm-hal.c
+++ b/framework-lgpio/pwm-hal.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * PWM Hardware Abstraction Layer (HAL) Implementation
  *
@@ -83,6 +84,8 @@ const pwm_pin_map_t g_pwm_pin_map_pi5[] = {
  * Internal Helper Functions
  * ============================================================================ */
 
+static void pwm_init_state(void); /* forward declaration — defined below UNIT_TESTING block */
+
 #ifdef UNIT_TESTING
 /**
  * @brief Reset all PWM state for unit tests.
@@ -100,6 +103,26 @@ void pwm_reset_state_for_testing(void) {
         g_pwm_channels[i].frequency_hz      = 0;
         g_pwm_channels[i].duty_cycle_percent = 0.0f;
         g_pwm_channels[i].polarity          = PWM_POLARITY_NORMAL;
+    }
+}
+
+/**
+ * @brief Fill all state slots with dummy entries to simulate slot exhaustion.
+ *
+ * Populates every g_pwm_channels slot with a fictional gpio_pin (100+i) and
+ * chip=0, channel=1 so that a subsequent pwm_init() for any real pin passes
+ * the conflict check (channel 0 is unused) but fails pwm_alloc_state() with
+ * NULL, causing pwm_init() to return PWM_ERROR_HARDWARE.
+ *
+ * Called at the start of the slot-exhaustion test case only.
+ * Only compiled with -DUNIT_TESTING=1.
+ */
+void pwm_fill_channels_for_testing(void) {
+    pwm_init_state(); /* mark initialized so pwm_init() won't wipe slots on entry */
+    for (int i = 0; i < MAX_PWM_CHANNELS; i++) {
+        g_pwm_channels[i].gpio_pin   = 100 + i; /* fictional pins, not in pin map */
+        g_pwm_channels[i].pwm_chip   = 0;
+        g_pwm_channels[i].pwm_channel = 1;       /* ch=1 ≠ ch=0 used by GPIO 18 */
     }
 }
 #endif /* UNIT_TESTING */
@@ -360,7 +383,7 @@ int pwm_write(int pin, float duty_cycle_percent) {
 
     // Calculate duty cycle in nanoseconds
     uint64_t period_ns = 1000000000ULL / state->frequency_hz;
-    uint64_t duty_cycle_ns = (uint64_t)((double)period_ns * (duty_cycle_percent / 100.0));
+    uint64_t duty_cycle_ns = (uint64_t)((double)period_ns * ((double)duty_cycle_percent / 100.0));
 
     // Set duty cycle
     char path[MAX_PATH_LEN];
@@ -441,7 +464,7 @@ int pwm_set_frequency(int pin, uint32_t freq_hz) {
     }
 
     // Update duty cycle to maintain percentage
-    uint64_t duty_cycle_ns = (uint64_t)((double)period_ns * (state->duty_cycle_percent / 100.0));
+    uint64_t duty_cycle_ns = (uint64_t)((double)period_ns * ((double)state->duty_cycle_percent / 100.0));
     snprintf(path, sizeof(path), "%s/pwmchip%d/pwm%d/duty_cycle",
              PWM_SYSFS_BASE, state->pwm_chip, state->pwm_channel);
     snprintf(value, sizeof(value), "%llu", (unsigned long long)duty_cycle_ns);
@@ -462,6 +485,7 @@ int pwm_set_frequency(int pin, uint32_t freq_hz) {
              PWM_SYSFS_BASE, state->pwm_chip, state->pwm_channel);
     result = pwm_sysfs_write(path, "1");
     if (result != PWM_SUCCESS) {
+        state->is_enabled = false;
         return result;
     }
 
@@ -502,7 +526,10 @@ int pwm_set_polarity(int pin, pwm_polarity_t polarity) {
         // Try to re-enable with old polarity
         snprintf(path, sizeof(path), "%s/pwmchip%d/pwm%d/enable",
                  PWM_SYSFS_BASE, state->pwm_chip, state->pwm_channel);
-        pwm_sysfs_write(path, "1");
+        int re_enable_result = pwm_sysfs_write(path, "1");
+        if (re_enable_result != PWM_SUCCESS) {
+            state->is_enabled = false;
+        }
         return result;
     }
 
@@ -511,6 +538,7 @@ int pwm_set_polarity(int pin, pwm_polarity_t polarity) {
              PWM_SYSFS_BASE, state->pwm_chip, state->pwm_channel);
     result = pwm_sysfs_write(path, "1");
     if (result != PWM_SUCCESS) {
+        state->is_enabled = false;
         return result;
     }
 
@@ -544,7 +572,7 @@ int pwm_get_status(int pin, pwm_status_t *status) {
     status->duty_cycle_percent = state->duty_cycle_percent;
     status->polarity = state->polarity;
     status->period_ns = 1000000000ULL / state->frequency_hz;
-    status->duty_cycle_ns = (uint64_t)((double)status->period_ns * (state->duty_cycle_percent / 100.0));
+    status->duty_cycle_ns = (uint64_t)((double)status->period_ns * ((double)state->duty_cycle_percent / 100.0));
 
     return PWM_SUCCESS;
 }

--- a/framework-lgpio/pwm-hal.c
+++ b/framework-lgpio/pwm-hal.c
@@ -12,26 +12,14 @@
  */
 
 #include "pwm-hal.h"
+#include "pwm-hal-internal.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <sys/stat.h>
 
 /* ============================================================================
  * Internal Data Structures and Constants
  * ============================================================================ */
-
-/**
- * @brief GPIO pin to PWM chip/channel mapping
- */
-typedef struct {
-    int gpio_pin;      /**< GPIO pin number (BCM) */
-    int pwm_chip;      /**< PWM chip number */
-    int pwm_channel;   /**< PWM channel (0 or 1) */
-} pwm_pin_map_t;
 
 /**
  * @brief PWM state tracking for each channel
@@ -54,18 +42,10 @@ typedef struct {
 static pwm_channel_state_t g_pwm_channels[MAX_PWM_CHANNELS];
 static bool g_pwm_initialized = false;
 
-/* Base path for PWM sysfs interface */
-#define PWM_SYSFS_BASE "/sys/class/pwm"
-
-/* Maximum path length for sysfs files */
-#define MAX_PATH_LEN 256
-
 /* Maximum string length for reading/writing sysfs values */
 #define MAX_VALUE_LEN 64
 
-/* ============================================================================
- * GPIO Pin to PWM Chip/Channel Mapping
- * ============================================================================ */
+/* Pin maps defined here (always linked). Sysfs implementations: see pwm-hal-sysfs.c */
 
 /**
  * Pi 1-4: pwmchip0
@@ -83,7 +63,7 @@ static bool g_pwm_initialized = false;
  * Note: GPIO 18/19 share the same PWM channels as GPIO 12/13.
  * Using both simultaneously requires additional conflict detection.
  */
-static const pwm_pin_map_t g_pwm_pin_map_pi1_4[] = {
+const pwm_pin_map_t g_pwm_pin_map_pi1_4[] = {
     {12, 0, 0},  // GPIO 12 -> pwmchip0, channel 0
     {13, 0, 1},  // GPIO 13 -> pwmchip0, channel 1
     {18, 0, 0},  // GPIO 18 -> pwmchip0, channel 0 (alt function)
@@ -91,7 +71,7 @@ static const pwm_pin_map_t g_pwm_pin_map_pi1_4[] = {
     {-1, -1, -1} // Sentinel
 };
 
-static const pwm_pin_map_t g_pwm_pin_map_pi5[] = {
+const pwm_pin_map_t g_pwm_pin_map_pi5[] = {
     {12, 2, 0},  // GPIO 12 -> pwmchip2, channel 0
     {13, 2, 1},  // GPIO 13 -> pwmchip2, channel 1
     {18, 2, 0},  // GPIO 18 -> pwmchip2, channel 0 (alt function)
@@ -102,6 +82,27 @@ static const pwm_pin_map_t g_pwm_pin_map_pi5[] = {
 /* ============================================================================
  * Internal Helper Functions
  * ============================================================================ */
+
+#ifdef UNIT_TESTING
+/**
+ * @brief Reset all PWM state for unit tests.
+ *
+ * Called at the start of each test case.  Only compiled with -DUNIT_TESTING=1.
+ */
+void pwm_reset_state_for_testing(void) {
+    g_pwm_initialized = false;
+    for (int i = 0; i < MAX_PWM_CHANNELS; i++) {
+        g_pwm_channels[i].gpio_pin          = -1;
+        g_pwm_channels[i].pwm_chip          = -1;
+        g_pwm_channels[i].pwm_channel       = -1;
+        g_pwm_channels[i].is_exported       = false;
+        g_pwm_channels[i].is_enabled        = false;
+        g_pwm_channels[i].frequency_hz      = 0;
+        g_pwm_channels[i].duty_cycle_percent = 0.0f;
+        g_pwm_channels[i].polarity          = PWM_POLARITY_NORMAL;
+    }
+}
+#endif /* UNIT_TESTING */
 
 /**
  * @brief Initialize global state tracking on first use
@@ -119,24 +120,6 @@ static void pwm_init_state(void) {
             g_pwm_channels[i].polarity = PWM_POLARITY_NORMAL;
         }
         g_pwm_initialized = true;
-    }
-}
-
-/**
- * @brief Detect Raspberry Pi model and return appropriate pin map
- *
- * Uses the presence of pwmchip2 to detect Pi 5 vs Pi 1-4.
- *
- * @return Pointer to pin map array
- */
-static const pwm_pin_map_t* pwm_get_pin_map(void) {
-    struct stat st;
-
-    // Check if pwmchip2 exists (Pi 5 indicator)
-    if (stat("/sys/class/pwm/pwmchip2", &st) == 0 && S_ISDIR(st.st_mode)) {
-        return g_pwm_pin_map_pi5;
-    } else {
-        return g_pwm_pin_map_pi1_4;
     }
 }
 
@@ -207,100 +190,6 @@ static void pwm_free_state(int pin) {
 }
 
 /**
- * @brief Write string to sysfs file
- *
- * @param path File path
- * @param value String value to write
- * @return PWM_SUCCESS on success, error code on failure
- */
-static int pwm_sysfs_write(const char* path, const char* value) {
-    int fd = open(path, O_WRONLY);
-    if (fd < 0) {
-        if (errno == EACCES || errno == EPERM) {
-            return PWM_ERROR_PERMISSION;
-        } else if (errno == EBUSY) {
-            return PWM_ERROR_BUSY;
-        } else if (errno == ENOENT || errno == ENODEV) {
-            return PWM_ERROR_NOT_EXPORTED;
-        } else {
-            return PWM_ERROR_IO;
-        }
-    }
-
-    ssize_t len = strlen(value);
-    ssize_t written = write(fd, value, len);
-    close(fd);
-
-    if (written != len) {
-        if (errno == EACCES || errno == EPERM) {
-            return PWM_ERROR_PERMISSION;
-        } else if (errno == EBUSY) {
-            return PWM_ERROR_BUSY;
-        } else if (errno == EINVAL) {
-            return PWM_ERROR_INVALID_PARAM;
-        } else {
-            return PWM_ERROR_IO;
-        }
-    }
-
-    return PWM_SUCCESS;
-}
-
-/**
- * @brief Read string from sysfs file
- *
- * @param path File path
- * @param value Buffer to store read value
- * @param max_len Maximum buffer length
- * @return PWM_SUCCESS on success, error code on failure
- */
-static int pwm_sysfs_read(const char* path, char* value, size_t max_len) {
-    int fd = open(path, O_RDONLY);
-    if (fd < 0) {
-        if (errno == EACCES || errno == EPERM) {
-            return PWM_ERROR_PERMISSION;
-        } else if (errno == ENOENT || errno == ENODEV) {
-            return PWM_ERROR_NOT_EXPORTED;
-        } else {
-            return PWM_ERROR_IO;
-        }
-    }
-
-    ssize_t len = read(fd, value, max_len - 1);
-    close(fd);
-
-    if (len < 0) {
-        return PWM_ERROR_IO;
-    }
-
-    value[len] = '\0';
-
-    // Remove trailing newline if present
-    if (len > 0 && value[len - 1] == '\n') {
-        value[len - 1] = '\0';
-    }
-
-    return PWM_SUCCESS;
-}
-
-/**
- * @brief Check if PWM channel is already exported
- *
- * @param chip PWM chip number
- * @param channel PWM channel number
- * @return true if exported, false otherwise
- */
-static bool pwm_is_exported(int chip, int channel) {
-    char path[MAX_PATH_LEN];
-    struct stat st;
-
-    snprintf(path, sizeof(path), "%s/pwmchip%d/pwm%d",
-             PWM_SYSFS_BASE, chip, channel);
-
-    return (stat(path, &st) == 0 && S_ISDIR(st.st_mode));
-}
-
-/**
  * @brief Export PWM channel to userspace
  *
  * @param chip PWM chip number
@@ -326,11 +215,11 @@ static int pwm_export(int chip, int channel) {
     }
 
     // Wait for sysfs to create the channel directory (up to 100ms)
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < PWM_EXPORT_RETRIES; i++) {
         if (pwm_is_exported(chip, channel)) {
             return PWM_SUCCESS;
         }
-        usleep(10000); // 10ms delay
+        pwm_sysfs_sleep_ms(10); /* 10ms; no-op in unit-test builds */
     }
 
     return PWM_ERROR_IO; // Export didn't complete in time
@@ -352,10 +241,10 @@ static int pwm_unexport(int chip, int channel) {
         return PWM_SUCCESS;
     }
 
-    // Disable before unexporting
+    /* Disable before unexporting — best-effort; unexport proceeds regardless of result. */
     snprintf(path, sizeof(path), "%s/pwmchip%d/pwm%d/enable",
              PWM_SYSFS_BASE, chip, channel);
-    pwm_sysfs_write(path, "0");
+    (void)pwm_sysfs_write(path, "0");
 
     // Unexport channel
     snprintf(path, sizeof(path), "%s/pwmchip%d/unexport", PWM_SYSFS_BASE, chip);
@@ -372,7 +261,7 @@ int pwm_init(int pin, uint32_t freq_hz) {
     int chip, channel;
     int result;
 
-    pwm_init_state();   // ensure sentinel values are set before conflict check
+    pwm_init_state();   // explicit; pwm_find_state also calls this — defense in depth
 
     // Validate frequency
     if (freq_hz < PWM_MIN_FREQUENCY_HZ || freq_hz > PWM_MAX_FREQUENCY_HZ) {
@@ -544,7 +433,10 @@ int pwm_set_frequency(int pin, uint32_t freq_hz) {
         // Try to re-enable with old settings
         snprintf(path, sizeof(path), "%s/pwmchip%d/pwm%d/enable",
                  PWM_SYSFS_BASE, state->pwm_chip, state->pwm_channel);
-        pwm_sysfs_write(path, "1");
+        int re_enable_result = pwm_sysfs_write(path, "1");
+        if (re_enable_result != PWM_SUCCESS) {
+            state->is_enabled = false;
+        }
         return result;
     }
 
@@ -558,7 +450,10 @@ int pwm_set_frequency(int pin, uint32_t freq_hz) {
         // Try to re-enable with new period and zero duty cycle
         snprintf(path, sizeof(path), "%s/pwmchip%d/pwm%d/enable",
                  PWM_SYSFS_BASE, state->pwm_chip, state->pwm_channel);
-        pwm_sysfs_write(path, "1");
+        int re_enable_result = pwm_sysfs_write(path, "1");
+        if (re_enable_result != PWM_SUCCESS) {
+            state->is_enabled = false;
+        }
         return result;
     }
 
@@ -600,6 +495,7 @@ int pwm_set_polarity(int pin, pwm_polarity_t polarity) {
     // Set polarity
     snprintf(path, sizeof(path), "%s/pwmchip%d/pwm%d/polarity",
              PWM_SYSFS_BASE, state->pwm_chip, state->pwm_channel);
+    /* kernel sysfs uses "inversed" (not "inverted") — see Documentation/driver-api/pwm.rst */
     const char* polarity_str = (polarity == PWM_POLARITY_NORMAL) ? "normal" : "inversed";
     result = pwm_sysfs_write(path, polarity_str);
     if (result != PWM_SUCCESS) {
@@ -624,6 +520,9 @@ int pwm_set_polarity(int pin, pwm_polarity_t polarity) {
     return PWM_SUCCESS;
 }
 
+/* TODO(#124): returns write-shadow state (last values set via this API), NOT live
+ * hardware state.  pwm_sysfs_read is available but unwired — see issue for design
+ * options (always-read-back, cache-invalidation, or document-as-mirror). */
 int pwm_get_status(int pin, pwm_status_t *status) {
     if (!status) {
         return PWM_ERROR_INVALID_PARAM;

--- a/framework-lgpio/pwm-hal.h
+++ b/framework-lgpio/pwm-hal.h
@@ -194,6 +194,9 @@ int pwm_set_polarity(int pin, pwm_polarity_t polarity);
  * @return PWM_SUCCESS on success, error code on failure
  *
  * @note status parameter must not be NULL
+ * @note Returns cached (write-shadow) state — values reflect the last written
+ *       configuration, not live hardware registers. Live readback is tracked
+ *       in issue #124.
  */
 int pwm_get_status(int pin, pwm_status_t *status);
 

--- a/framework-lgpio/pwm-hal.h
+++ b/framework-lgpio/pwm-hal.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * PWM Hardware Abstraction Layer (HAL) for Linux ARM Platform
  *

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,6 +15,9 @@ pre-commit>=3.5.0,<5.0.0
 mypy>=1.0.0,<2.0.0
 types-setuptools
 
+# PlatformIO (needed by test, lint, and coverage-report CI jobs)
+platformio>=6.1.0,<7.0.0
+
 # Documentation
 sphinx>=6.0.0,<9.0.0
 sphinx-rtd-theme>=1.2.0,<3.0.0

--- a/tests/stubs/pwm-hal-sysfs-stub.c
+++ b/tests/stubs/pwm-hal-sysfs-stub.c
@@ -24,6 +24,9 @@ static int  s_export_delay_remaining;
 static bool s_export_written;
 static const char *s_write_fail_suffix;
 static int         s_write_fail_error;
+static const char *s_write_fail_after_suffix;
+static int         s_write_fail_after_error;
+static int         s_write_fail_after_count;
 
 /* ---- Stub control ---- */
 
@@ -31,8 +34,11 @@ void stub_reset(void) {
     s_use_pi5 = false;
     s_export_delay_remaining = 0;
     s_export_written = false;
-    s_write_fail_suffix = NULL;
-    s_write_fail_error  = 0;
+    s_write_fail_suffix       = NULL;
+    s_write_fail_error        = 0;
+    s_write_fail_after_suffix = NULL;
+    s_write_fail_after_error  = 0;
+    s_write_fail_after_count  = 0;
     for (int c = 0; c < STUB_MAX_CHIPS; c++) {
         for (int ch = 0; ch < STUB_MAX_CHANNELS; ch++) {
             s_exported[c][ch] = false;
@@ -51,6 +57,13 @@ void stub_set_export_delay(int n_failures) {
 void stub_set_write_fail_on(const char *path_suffix, int error_code) {
     s_write_fail_suffix = path_suffix;
     s_write_fail_error  = error_code;
+}
+
+void stub_set_write_fail_after(const char *path_suffix, int error_code,
+                               int n_successes_before_fail) {
+    s_write_fail_after_suffix = path_suffix;
+    s_write_fail_after_error  = error_code;
+    s_write_fail_after_count  = n_successes_before_fail;
 }
 
 /* ---- Seam function implementations ---- */
@@ -72,6 +85,25 @@ int pwm_sysfs_write(const char *path, const char *value) {
         if (plen >= slen && strcmp(path + plen - slen, s_write_fail_suffix) == 0) {
             s_write_fail_suffix = NULL; /* consume — one-shot */
             return s_write_fail_error;
+        }
+    }
+    /*
+     * Count-based write failure injection: if a suffix was registered via
+     * stub_set_write_fail_after(), check whether this path ends with it.
+     * Each matching write decrements the counter.  When the counter reaches
+     * zero, the trigger fires (one-shot) and returns the configured error.
+     */
+    if (s_write_fail_after_suffix != NULL) {
+        size_t plen = strlen(path);
+        size_t slen = strlen(s_write_fail_after_suffix);
+        if (plen >= slen &&
+            strcmp(path + plen - slen, s_write_fail_after_suffix) == 0) {
+            if (s_write_fail_after_count > 0) {
+                s_write_fail_after_count--;
+            } else {
+                s_write_fail_after_suffix = NULL; /* consume — one-shot */
+                return s_write_fail_after_error;
+            }
         }
     }
     /*

--- a/tests/stubs/pwm-hal-sysfs-stub.c
+++ b/tests/stubs/pwm-hal-sysfs-stub.c
@@ -84,7 +84,7 @@ int pwm_sysfs_write(const char *path, const char *value) {
      *   PWM_SYSFS_BASE "/pwmchipN/unexport" → mark chip N, channel=value unexported
      * All other paths succeed silently (period, duty_cycle, enable, polarity).
      */
-    if (sscanf(path, "/sys/class/pwm/pwmchip%d/export", &chip) == 1) {
+    if (sscanf(path, PWM_SYSFS_BASE "/pwmchip%d/export", &chip) == 1) {
         int channel = -1;
         /*
          * Parse channel from value string.  Use sscanf so malformed input
@@ -101,7 +101,7 @@ int pwm_sysfs_write(const char *path, const char *value) {
         }
         return PWM_SUCCESS;
     }
-    if (sscanf(path, "/sys/class/pwm/pwmchip%d/unexport", &chip) == 1) {
+    if (sscanf(path, PWM_SYSFS_BASE "/pwmchip%d/unexport", &chip) == 1) {
         int channel = -1;
         /*
          * Parse channel from value string.  Use sscanf so malformed input

--- a/tests/stubs/pwm-hal-sysfs-stub.c
+++ b/tests/stubs/pwm-hal-sysfs-stub.c
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * pwm-hal-sysfs-stub.c — Test stub for the pwm-hal sysfs seam.
+ *
+ * Implements the four seam functions declared in pwm-hal-internal.h without
+ * touching the filesystem.  Export state is tracked in a small table.
+ */
+#include "pwm-hal-sysfs-stub.h"
+#include "pwm-hal-internal.h"
+#include "pwm-hal.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+
+/* Tracks which chip+channel pairs have been exported. */
+/* Chips 0..7, channels 0..1 — matches MAX_PWM_CHANNELS and HAL limits. */
+#define STUB_MAX_CHIPS    8
+#define STUB_MAX_CHANNELS 2
+
+static bool s_use_pi5;
+static bool s_exported[STUB_MAX_CHIPS][STUB_MAX_CHANNELS];
+static int  s_export_delay_remaining;
+static bool s_export_written;
+static const char *s_write_fail_suffix;
+static int         s_write_fail_error;
+
+/* ---- Stub control ---- */
+
+void stub_reset(void) {
+    s_use_pi5 = false;
+    s_export_delay_remaining = 0;
+    s_export_written = false;
+    s_write_fail_suffix = NULL;
+    s_write_fail_error  = 0;
+    for (int c = 0; c < STUB_MAX_CHIPS; c++) {
+        for (int ch = 0; ch < STUB_MAX_CHANNELS; ch++) {
+            s_exported[c][ch] = false;
+        }
+    }
+}
+
+void stub_set_pi5(bool is_pi5) {
+    s_use_pi5 = is_pi5;
+}
+
+void stub_set_export_delay(int n_failures) {
+    s_export_delay_remaining = n_failures;
+}
+
+void stub_set_write_fail_on(const char *path_suffix, int error_code) {
+    s_write_fail_suffix = path_suffix;
+    s_write_fail_error  = error_code;
+}
+
+/* ---- Seam function implementations ---- */
+
+void pwm_sysfs_sleep_ms(int ms) {
+    (void)ms; /* no-op in unit-test builds — delays are not modelled */
+}
+
+int pwm_sysfs_write(const char *path, const char *value) {
+    int chip;
+    /*
+     * One-shot write failure injection: if a suffix was registered via
+     * stub_set_write_fail_on(), check whether this path ends with it.
+     * If it matches, consume the one-shot and return the configured error.
+     */
+    if (s_write_fail_suffix != NULL) {
+        size_t plen = strlen(path);
+        size_t slen = strlen(s_write_fail_suffix);
+        if (plen >= slen && strcmp(path + plen - slen, s_write_fail_suffix) == 0) {
+            s_write_fail_suffix = NULL; /* consume — one-shot */
+            return s_write_fail_error;
+        }
+    }
+    /*
+     * Detect export/unexport by matching the sysfs path pattern.
+     * The prefix "/sys/class/pwm/pwmchipN/" is derived from PWM_SYSFS_BASE
+     * (defined in pwm-hal-internal.h).  If PWM_SYSFS_BASE changes, update
+     * the sscanf format strings below to match.
+     *
+     *   PWM_SYSFS_BASE "/pwmchipN/export"   → mark chip N, channel=value exported
+     *   PWM_SYSFS_BASE "/pwmchipN/unexport" → mark chip N, channel=value unexported
+     * All other paths succeed silently (period, duty_cycle, enable, polarity).
+     */
+    if (sscanf(path, "/sys/class/pwm/pwmchip%d/export", &chip) == 1) {
+        int channel = -1;
+        /*
+         * Parse channel from value string.  Use sscanf so malformed input
+         * returns an out-of-range channel that the bounds check below rejects,
+         * rather than silently returning 0 (atoi behaviour).
+         */
+        if (sscanf(value, "%d", &channel) != 1) {
+            channel = -1;
+        }
+        if (chip >= 0 && chip < STUB_MAX_CHIPS &&
+            channel >= 0 && channel < STUB_MAX_CHANNELS) {
+            s_exported[chip][channel] = true;
+            s_export_written = true;
+        }
+        return PWM_SUCCESS;
+    }
+    if (sscanf(path, "/sys/class/pwm/pwmchip%d/unexport", &chip) == 1) {
+        int channel = -1;
+        /*
+         * Parse channel from value string.  Use sscanf so malformed input
+         * returns an out-of-range channel that the bounds check below rejects,
+         * rather than silently returning 0 (atoi behaviour).
+         */
+        if (sscanf(value, "%d", &channel) != 1) {
+            channel = -1;
+        }
+        if (chip >= 0 && chip < STUB_MAX_CHIPS &&
+            channel >= 0 && channel < STUB_MAX_CHANNELS) {
+            s_exported[chip][channel] = false;
+        }
+        return PWM_SUCCESS;
+    }
+    return PWM_SUCCESS;
+}
+
+int pwm_sysfs_read(const char *path, char *value, size_t max_len) {
+    (void)path;
+    /* Return a safe default — tests that need specific read values should
+     * extend the stub with a per-path override table. */
+    if (max_len > 0) {
+        strncpy(value, "0", max_len);
+        value[max_len - 1] = '\0';
+    }
+    return PWM_SUCCESS;
+}
+
+bool pwm_is_exported(int chip, int channel) {
+    if (chip < 0 || chip >= STUB_MAX_CHIPS)         return false;
+    if (channel < 0 || channel >= STUB_MAX_CHANNELS) return false;
+    if (!s_exported[chip][channel])                  return false;
+    /* Simulate delayed sysfs directory creation for timeout path testing.
+     * The delay counter only activates once the export write has been seen,
+     * so pre-write calls to pwm_is_exported() cannot prematurely consume it. */
+    if (s_export_written && s_export_delay_remaining > 0) {
+        s_export_delay_remaining--;
+        return false;
+    }
+    return true;
+}
+
+const pwm_pin_map_t *pwm_get_pin_map(void) {
+    return s_use_pi5 ? g_pwm_pin_map_pi5 : g_pwm_pin_map_pi1_4;
+}

--- a/tests/stubs/pwm-hal-sysfs-stub.h
+++ b/tests/stubs/pwm-hal-sysfs-stub.h
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * pwm-hal-sysfs-stub.h — Test stub control interface for pwm-hal sysfs seam.
+ *
+ * Include this in test files that need to control stub behaviour.
+ */
+#ifndef PWM_HAL_SYSFS_STUB_H
+#define PWM_HAL_SYSFS_STUB_H
+
+#include <stdbool.h>
+
+/**
+ * Reset all stub state.  Call at the start of every test case.
+ */
+void stub_reset(void);
+
+/**
+ * Configure the pin map returned by pwm_get_pin_map().
+ *
+ * @param is_pi5  true  → return Pi 5 map (GPIO 18 → chip 2, channel 0)
+ *                false → return Pi 1-4 map (GPIO 18 → chip 0, channel 0)  [default]
+ */
+void stub_set_pi5(bool is_pi5);
+
+/**
+ * Simulate a delayed export response for testing the pwm_export() timeout path.
+ *
+ * When n_failures > 0, the next n_failures calls to pwm_is_exported() will
+ * return false even after the channel has been written to export.  After
+ * n_failures calls, pwm_is_exported() returns true normally.
+ *
+ * Reset to 0 by stub_reset().
+ *
+ * @param n_failures  Number of calls to return false before returning true.
+ *                    Pass 0 to disable the delay (default).
+ */
+void stub_set_export_delay(int n_failures);
+
+/**
+ * Make the next pwm_sysfs_write() call whose path ends with path_suffix
+ * return error_code instead of PWM_SUCCESS.
+ * Only matches once — the match is consumed after one trigger.
+ * Pass NULL to disable (default).
+ * Reset to NULL by stub_reset().
+ */
+void stub_set_write_fail_on(const char *path_suffix, int error_code);
+
+#endif /* PWM_HAL_SYSFS_STUB_H */

--- a/tests/stubs/pwm-hal-sysfs-stub.h
+++ b/tests/stubs/pwm-hal-sysfs-stub.h
@@ -45,4 +45,16 @@ void stub_set_export_delay(int n_failures);
  */
 void stub_set_write_fail_on(const char *path_suffix, int error_code);
 
+/**
+ * Set write failure for path_suffix to fire after n_successes_before_fail
+ * successful writes to that suffix.  Use for testing double-failure paths.
+ *
+ * After n_successes_before_fail matching writes succeed, the next matching
+ * write returns error_code.  Only fires once — the trigger is consumed.
+ * Pass NULL to disable (default).
+ * Reset to NULL by stub_reset().
+ */
+void stub_set_write_fail_after(const char *path_suffix, int error_code,
+                               int n_successes_before_fail);
+
 #endif /* PWM_HAL_SYSFS_STUB_H */

--- a/tests/test_pwm_hal.c
+++ b/tests/test_pwm_hal.c
@@ -1,0 +1,662 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * test_pwm_hal.c — Plain-C unit tests for framework-lgpio/pwm-hal.c
+ *
+ * Each test function:
+ *   1. Calls stub_reset()              to clear stub export state
+ *   2. Calls pwm_reset_state_for_testing() to clear HAL channel table
+ *   3. Exercises one behaviour
+ *   4. assert()s the expected result — terminates on failure with a diagnostic
+ *   5. Prints "PASS <name>" on success
+ *
+ * Build with CMake target test_pwm_hal (see CMakeLists.txt).
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include <stdbool.h>
+
+#include "pwm-hal.h"
+#include "pwm-hal-internal.h"
+#include "pwm-hal-sysfs-stub.h"
+
+/* ============================================================
+ * Helper macro — print test name, call function, check result
+ * ============================================================ */
+#define RUN(fn) do { fn(); printf("PASS %s\n", #fn); } while (0)
+
+/* ============================================================
+ * Test cases
+ * ============================================================ */
+
+/**
+ * T1: pwm_init(18, 1000) returns PWM_SUCCESS.
+ * GPIO 18 maps to chip 0, channel 0 on Pi 1-4 (default stub map).
+ */
+static void test_init_gpio18_succeeds(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    int result = pwm_init(18, 1000);
+    assert(result == PWM_SUCCESS);
+}
+
+/**
+ * T2: pwm_init(13, 1000) returns PWM_SUCCESS.
+ * GPIO 13 maps to chip 0, channel 1 — different channel than GPIO 18.
+ */
+static void test_init_gpio13_succeeds(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    int result = pwm_init(13, 1000);
+    assert(result == PWM_SUCCESS);
+}
+
+/**
+ * T3: After init on GPIO 18 (chip 0, channel 0), init on GPIO 12 returns
+ * PWM_ERROR_BUSY because GPIO 12 maps to the same chip 0, channel 0.
+ */
+static void test_init_conflict_gpio12_after_gpio18(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    int result = pwm_init(12, 1000);
+    assert(result == PWM_ERROR_BUSY);
+}
+
+/**
+ * T4: Re-initialising the same pin does not return PWM_ERROR_BUSY.
+ * The conflict check skips entries with gpio_pin == pin.
+ */
+static void test_reinit_same_pin_not_busy(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    int result = pwm_init(18, 2000);
+    assert(result == PWM_SUCCESS);
+}
+
+/**
+ * T5: pwm_write(18, 50.0) before any pwm_init returns PWM_ERROR_NOT_EXPORTED.
+ * pwm_find_state() returns NULL → NOT_EXPORTED.
+ */
+static void test_write_before_init_fails(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    int result = pwm_write(18, 50.0f);
+    assert(result == PWM_ERROR_NOT_EXPORTED);
+}
+
+/**
+ * T6: After pwm_deinit(18), GPIO 12 can be initialised on the same channel.
+ * pwm_deinit frees the state slot; the conflict check no longer finds GPIO 18.
+ */
+static void test_deinit_releases_state(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    assert(pwm_deinit(18) == PWM_SUCCESS);
+
+    int result = pwm_init(12, 1000);
+    assert(result == PWM_SUCCESS);
+}
+
+/**
+ * T7: pwm_pin_is_valid() correctly classifies pins.
+ * GPIO 99 is not in either map; GPIO 18 is.
+ */
+static void test_pin_is_valid_rejects_invalid(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_pin_is_valid(99) == false);
+    assert(pwm_pin_is_valid(18) == true);
+}
+
+/**
+ * T8: pwm_init(18, 0) returns PWM_ERROR_INVALID_PARAM.
+ * Frequency 0 is below PWM_MIN_FREQUENCY_HZ.
+ */
+static void test_init_invalid_freq(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    int result = pwm_init(18, 0);
+    assert(result == PWM_ERROR_INVALID_PARAM);
+}
+
+/**
+ * T9: With stub_set_pi5(true), GPIO 18 resolves to chip 2, channel 0.
+ * Verifies that pwm_get_chip_channel honours the stub's pin map.
+ */
+static void test_pi5_pin_map(void) {
+    stub_reset();
+    stub_set_pi5(true);
+    pwm_reset_state_for_testing();
+
+    int chip = -1, channel = -1;
+    int result = pwm_get_chip_channel(18, &chip, &channel);
+
+    assert(result  == PWM_SUCCESS);
+    assert(chip    == 2);
+    assert(channel == 0);
+}
+
+/**
+ * T10: pwm_write(18, 50.0) after init returns PWM_SUCCESS.
+ */
+static void test_write_after_init_succeeds(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    int result = pwm_write(18, 50.0f);
+    assert(result == PWM_SUCCESS);
+}
+
+/**
+ * T11: pwm_write(18, -1.0) returns PWM_ERROR_INVALID_PARAM.
+ */
+static void test_write_invalid_duty_low(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    int result = pwm_write(18, -1.0f);
+    assert(result == PWM_ERROR_INVALID_PARAM);
+}
+
+/**
+ * T12: pwm_write(18, 101.0) returns PWM_ERROR_INVALID_PARAM.
+ */
+static void test_write_invalid_duty_high(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    int result = pwm_write(18, 101.0f);
+    assert(result == PWM_ERROR_INVALID_PARAM);
+}
+
+/**
+ * T13: pwm_init(99, 1000) returns PWM_ERROR_INVALID_PIN.
+ * GPIO 99 is not in the pin map.
+ */
+static void test_init_invalid_pin(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    int result = pwm_init(99, 1000);
+    assert(result == PWM_ERROR_INVALID_PIN);
+}
+
+/**
+ * T14: pwm_set_frequency(18, 2000) after init returns PWM_SUCCESS.
+ */
+static void test_set_frequency_valid(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    int result = pwm_set_frequency(18, 2000);
+    assert(result == PWM_SUCCESS);
+}
+
+/**
+ * T15: pwm_set_polarity(18, PWM_POLARITY_NORMAL) after init returns PWM_SUCCESS.
+ */
+static void test_set_polarity_normal(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    int result = pwm_set_polarity(18, PWM_POLARITY_NORMAL);
+    assert(result == PWM_SUCCESS);
+}
+
+/**
+ * T16: pwm_set_polarity(18, PWM_POLARITY_INVERTED) after init returns PWM_SUCCESS.
+ */
+static void test_set_polarity_inversed(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    int result = pwm_set_polarity(18, PWM_POLARITY_INVERTED);
+    assert(result == PWM_SUCCESS);
+}
+
+/**
+ * T17: pwm_get_status(18, &status) after init reflects the expected state.
+ */
+static void test_get_status_after_init(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    pwm_status_t status;
+    int result = pwm_get_status(18, &status);
+    assert(result == PWM_SUCCESS);
+    assert(status.gpio_pin == 18);
+    assert(status.pwm_chip == 0);
+    assert(status.pwm_channel == 0);
+    assert(status.is_enabled == true);
+    assert(status.is_exported == true);
+    assert(status.frequency_hz == 1000);
+    assert(status.duty_cycle_percent == 0.0f);
+    assert(status.polarity == PWM_POLARITY_NORMAL);
+}
+
+/**
+ * T18: pwm_is_enabled(18) returns true after init.
+ */
+static void test_is_enabled_after_init(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    assert(pwm_is_enabled(18) == true);
+}
+
+/**
+ * T19: pwm_is_enabled(18) returns false before any init.
+ */
+static void test_is_enabled_before_init(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_is_enabled(18) == false);
+}
+
+/**
+ * T20: With stub_set_export_delay(PWM_EXPORT_RETRIES), pwm_init(18, 1000) returns
+ * PWM_ERROR_IO.
+ *
+ * COUPLING NOTE: stub_set_export_delay() must receive exactly PWM_EXPORT_RETRIES
+ * (defined in pwm-hal-internal.h) to reliably exhaust all iterations of the retry
+ * loop in pwm_export().  A value smaller than PWM_EXPORT_RETRIES would let the
+ * loop succeed partway through and return PWM_SUCCESS instead.  If the retry loop
+ * bound changes, update PWM_EXPORT_RETRIES — this test will automatically track it.
+ */
+static void test_export_timeout(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    stub_set_export_delay(PWM_EXPORT_RETRIES);
+    int result = pwm_init(18, 1000);
+    assert(result == PWM_ERROR_IO);
+}
+
+/**
+ * T21: pwm_set_frequency(18, 1000) before init returns PWM_ERROR_NOT_EXPORTED.
+ * pwm_find_state() returns NULL → NOT_EXPORTED.
+ */
+static void test_set_frequency_before_init_fails(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    int result = pwm_set_frequency(18, 1000);
+    assert(result == PWM_ERROR_NOT_EXPORTED);
+}
+
+/**
+ * T22: pwm_set_frequency(18, 0) after init returns PWM_ERROR_INVALID_PARAM.
+ * Frequency 0 is below PWM_MIN_FREQUENCY_HZ.
+ */
+static void test_set_frequency_invalid_freq(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    int result = pwm_set_frequency(18, 0);
+    assert(result == PWM_ERROR_INVALID_PARAM);
+}
+
+/**
+ * T23: pwm_set_polarity(18, PWM_POLARITY_NORMAL) before init returns
+ * PWM_ERROR_NOT_EXPORTED.
+ */
+static void test_set_polarity_before_init_fails(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    int result = pwm_set_polarity(18, PWM_POLARITY_NORMAL);
+    assert(result == PWM_ERROR_NOT_EXPORTED);
+}
+
+/**
+ * T24: pwm_set_polarity(18, 99) after init returns PWM_ERROR_INVALID_PARAM.
+ * 99 is not a valid pwm_polarity_t value (valid: 0=NORMAL, 1=INVERTED).
+ */
+static void test_set_polarity_invalid_value(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    int result = pwm_set_polarity(18, (pwm_polarity_t)99);
+    assert(result == PWM_ERROR_INVALID_PARAM);
+}
+
+/**
+ * T25: pwm_deinit(18) before any init returns PWM_SUCCESS.
+ * pwm_find_state() returns NULL → early return PWM_SUCCESS (idempotent).
+ */
+static void test_deinit_before_init_succeeds(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    int result = pwm_deinit(18);
+    assert(result == PWM_SUCCESS);
+}
+
+/**
+ * T26: pwm_get_status(18, NULL) returns PWM_ERROR_INVALID_PARAM.
+ * NULL status pointer is rejected before state lookup.
+ */
+static void test_get_status_null_ptr_fails(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    int result = pwm_get_status(18, NULL);
+    assert(result == PWM_ERROR_INVALID_PARAM);
+}
+
+/**
+ * T27: pwm_get_chip_channel(18, NULL, NULL) returns PWM_ERROR_INVALID_PARAM.
+ * NULL output pointers are rejected before map lookup.
+ */
+static void test_get_chip_channel_null_fails(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    int result = pwm_get_chip_channel(18, NULL, NULL);
+    assert(result == PWM_ERROR_INVALID_PARAM);
+}
+
+/**
+ * T28: pwm_write(18, 0.0) returns PWM_SUCCESS.
+ * 0.0% is the lower boundary of the valid duty cycle range [0.0, 100.0].
+ */
+static void test_write_boundary_zero(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    int result = pwm_write(18, 0.0f);
+    assert(result == PWM_SUCCESS);
+}
+
+/**
+ * T29: pwm_write(18, 100.0) returns PWM_SUCCESS.
+ * 100.0% is the upper boundary of the valid duty cycle range [0.0, 100.0].
+ */
+static void test_write_boundary_full(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    int result = pwm_write(18, 100.0f);
+    assert(result == PWM_SUCCESS);
+}
+
+/**
+ * T30: pwm_init(18, 1000) returns PWM_ERROR_IO when the period write fails.
+ * The period write is the first sysfs write after export succeeds in pwm_init.
+ */
+static void test_init_fails_on_period_write(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    stub_set_write_fail_on("/period", PWM_ERROR_IO);
+    int result = pwm_init(18, 1000);
+    assert(result == PWM_ERROR_IO);
+}
+
+/**
+ * T31: pwm_init(18, 1000) returns PWM_ERROR_IO when the duty_cycle write fails.
+ */
+static void test_init_fails_on_duty_write(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    stub_set_write_fail_on("/duty_cycle", PWM_ERROR_IO);
+    int result = pwm_init(18, 1000);
+    assert(result == PWM_ERROR_IO);
+}
+
+/**
+ * T32: pwm_init(18, 1000) returns PWM_ERROR_IO when the enable write fails.
+ */
+static void test_init_fails_on_enable_write(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    stub_set_write_fail_on("/enable", PWM_ERROR_IO);
+    int result = pwm_init(18, 1000);
+    assert(result == PWM_ERROR_IO);
+}
+
+/**
+ * T33: pwm_set_frequency(18, 2000) returns PWM_ERROR_IO when the period write fails.
+ * pwm_set_frequency first disables (write to .../enable), then writes period.
+ * Setting write_fail_on("/period") lets the disable write succeed and fails only
+ * the period write.  The one-shot is consumed on "/period", so the re-enable
+ * attempt succeeds.  The return code must be PWM_ERROR_IO.
+ */
+static void test_set_frequency_fails_on_period_write(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    stub_set_write_fail_on("/period", PWM_ERROR_IO);
+    int result = pwm_set_frequency(18, 2000);
+    assert(result == PWM_ERROR_IO);
+}
+
+/**
+ * T34: pwm_set_polarity(18, PWM_POLARITY_INVERTED) returns PWM_ERROR_IO when the
+ * polarity write fails.  pwm_set_polarity first disables, then writes polarity.
+ * Setting write_fail_on("/polarity") lets the disable succeed and fails the
+ * polarity write.  The re-enable attempt succeeds (one-shot consumed).
+ */
+static void test_set_polarity_fails_on_polarity_write(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    stub_set_write_fail_on("/polarity", PWM_ERROR_IO);
+    int result = pwm_set_polarity(18, PWM_POLARITY_INVERTED);
+    assert(result == PWM_ERROR_IO);
+}
+
+/**
+ * T35: pwm_error_string() returns a non-NULL, non-empty string for every
+ * defined error code.
+ */
+static void test_error_string_all_codes(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    const pwm_error_t codes[] = {
+        PWM_SUCCESS,
+        PWM_ERROR_INVALID_PIN,
+        PWM_ERROR_PERMISSION,
+        PWM_ERROR_BUSY,
+        PWM_ERROR_NOT_EXPORTED,
+        PWM_ERROR_INVALID_PARAM,
+        PWM_ERROR_IO,
+        PWM_ERROR_NOT_ENABLED,
+        PWM_ERROR_HARDWARE,
+    };
+    for (size_t i = 0; i < sizeof(codes) / sizeof(codes[0]); i++) {
+        const char *s = pwm_error_string(codes[i]);
+        assert(s != NULL);
+        assert(s[0] != '\0');
+    }
+}
+
+/**
+ * T36: pwm_error_string() with an unknown code returns a non-NULL pointer
+ * (the "Unknown error" default branch).
+ */
+static void test_error_string_unknown_code(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    const char *s = pwm_error_string((pwm_error_t)-99);
+    assert(s != NULL);
+    assert(s[0] != '\0');
+}
+
+/**
+ * T37: pwm_pin_is_valid() returns true for all Pi 1-4 PWM-capable GPIOs
+ * (12, 13, 18, 19) and false for non-PWM GPIOs (99, 0, 1, 4).
+ */
+static void test_pin_is_valid_all_pi14_pins(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_pin_is_valid(12)  == true);
+    assert(pwm_pin_is_valid(13)  == true);
+    assert(pwm_pin_is_valid(18)  == true);
+    assert(pwm_pin_is_valid(19)  == true);
+    assert(pwm_pin_is_valid(99)  == false);
+    assert(pwm_pin_is_valid(0)   == false);
+    assert(pwm_pin_is_valid(1)   == false);
+    assert(pwm_pin_is_valid(4)   == false);
+}
+
+/**
+ * T38: With stub_set_pi5(true), pwm_pin_is_valid() returns true for
+ * Pi 5 PWM GPIOs (12, 13, 18, 19) and false for GPIO 99.
+ */
+static void test_pin_is_valid_pi5_pins(void) {
+    stub_reset();
+    stub_set_pi5(true);
+    pwm_reset_state_for_testing();
+
+    assert(pwm_pin_is_valid(12)  == true);
+    assert(pwm_pin_is_valid(13)  == true);
+    assert(pwm_pin_is_valid(18)  == true);
+    assert(pwm_pin_is_valid(19)  == true);
+    assert(pwm_pin_is_valid(99)  == false);
+}
+
+/**
+ * T39: pwm_init(18, PWM_MAX_FREQUENCY_HZ + 1) returns PWM_ERROR_INVALID_PARAM.
+ * Frequency above PWM_MAX_FREQUENCY_HZ is rejected.
+ */
+static void test_init_freq_too_high(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    int result = pwm_init(18, PWM_MAX_FREQUENCY_HZ + 1);
+    assert(result == PWM_ERROR_INVALID_PARAM);
+}
+
+/**
+ * T40: pwm_get_status(18, &status) before any init returns PWM_ERROR_NOT_EXPORTED.
+ * pwm_find_state() returns NULL → NOT_EXPORTED.
+ */
+static void test_get_status_before_init_fails(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    pwm_status_t status;
+    int result = pwm_get_status(18, &status);
+    assert(result == PWM_ERROR_NOT_EXPORTED);
+}
+
+/**
+ * T41: pwm_write() propagates a sysfs I/O error from pwm_sysfs_write().
+ * After a successful init, injecting a write failure on the duty_cycle path
+ * causes pwm_write() to return PWM_ERROR_IO.
+ */
+static void test_write_fails_on_sysfs_io(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    stub_set_write_fail_on("/duty_cycle", PWM_ERROR_IO);
+    int result = pwm_write(18, 50.0f);
+    assert(result == PWM_ERROR_IO);
+}
+
+/**
+ * T42: pwm_set_frequency() propagates a sysfs I/O error on the duty-cycle
+ * update step. After init, injecting a write failure on the duty_cycle path
+ * causes pwm_set_frequency() to return PWM_ERROR_IO (init already consumed
+ * the duty_cycle write, so the fail fires on pwm_set_frequency's duty write).
+ */
+static void test_set_frequency_fails_on_duty_write(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    stub_set_write_fail_on("/duty_cycle", PWM_ERROR_IO);
+    int result = pwm_set_frequency(18, 2000);
+    assert(result == PWM_ERROR_IO);
+}
+
+/* ============================================================
+ * Main
+ * ============================================================ */
+
+int main(void) {
+    /* Known gap: PWM_ERROR_HARDWARE (slot exhaustion at MAX_PWM_CHANNELS=8)
+     * is not tested. The Pi 1-4 stub map provides only 2 distinct chip/channel
+     * pairs, making it impossible to exhaust 8 slots without extending the stub.
+     * Tracked as a future improvement. */
+
+    RUN(test_init_gpio18_succeeds);
+    RUN(test_init_gpio13_succeeds);
+    RUN(test_init_conflict_gpio12_after_gpio18);
+    RUN(test_reinit_same_pin_not_busy);
+    RUN(test_write_before_init_fails);
+    RUN(test_deinit_releases_state);
+    RUN(test_pin_is_valid_rejects_invalid);
+    RUN(test_init_invalid_freq);
+    RUN(test_pi5_pin_map);
+    RUN(test_write_after_init_succeeds);
+    RUN(test_write_invalid_duty_low);
+    RUN(test_write_invalid_duty_high);
+    RUN(test_init_invalid_pin);
+    RUN(test_set_frequency_valid);
+    RUN(test_set_polarity_normal);
+    RUN(test_set_polarity_inversed);
+    RUN(test_get_status_after_init);
+    RUN(test_is_enabled_after_init);
+    RUN(test_is_enabled_before_init);
+    RUN(test_export_timeout);
+    RUN(test_set_frequency_before_init_fails);
+    RUN(test_set_frequency_invalid_freq);
+    RUN(test_set_polarity_before_init_fails);
+    RUN(test_set_polarity_invalid_value);
+    RUN(test_deinit_before_init_succeeds);
+    RUN(test_get_status_null_ptr_fails);
+    RUN(test_get_chip_channel_null_fails);
+    RUN(test_write_boundary_zero);
+    RUN(test_write_boundary_full);
+    RUN(test_init_fails_on_period_write);
+    RUN(test_init_fails_on_duty_write);
+    RUN(test_init_fails_on_enable_write);
+    RUN(test_set_frequency_fails_on_period_write);
+    RUN(test_set_polarity_fails_on_polarity_write);
+    RUN(test_error_string_all_codes);
+    RUN(test_error_string_unknown_code);
+    RUN(test_pin_is_valid_all_pi14_pins);
+    RUN(test_pin_is_valid_pi5_pins);
+    RUN(test_init_freq_too_high);
+    RUN(test_get_status_before_init_fails);
+    RUN(test_write_fails_on_sysfs_io);
+    RUN(test_set_frequency_fails_on_duty_write);
+
+    printf("\nAll 42 tests passed.\n");
+    return 0;
+}

--- a/tests/test_pwm_hal.c
+++ b/tests/test_pwm_hal.c
@@ -23,7 +23,8 @@
 /* ============================================================
  * Helper macro — print test name, call function, check result
  * ============================================================ */
-#define RUN(fn) do { fn(); printf("PASS %s\n", #fn); } while (0)
+static int g_tests_run = 0;
+#define RUN(fn) do { fn(); g_tests_run++; printf("PASS %s\n", #fn); } while (0)
 
 /* ============================================================
  * Test cases
@@ -196,7 +197,8 @@ static void test_init_invalid_pin(void) {
 }
 
 /**
- * T14: pwm_set_frequency(18, 2000) after init returns PWM_SUCCESS.
+ * T14: pwm_set_frequency(18, 2000) after init returns PWM_SUCCESS and updates
+ * shadow state — status.frequency_hz must reflect the new frequency.
  */
 static void test_set_frequency_valid(void) {
     stub_reset();
@@ -205,6 +207,9 @@ static void test_set_frequency_valid(void) {
     assert(pwm_init(18, 1000) == PWM_SUCCESS);
     int result = pwm_set_frequency(18, 2000);
     assert(result == PWM_SUCCESS);
+    pwm_status_t status;
+    assert(pwm_get_status(18, &status) == PWM_SUCCESS);
+    assert(status.frequency_hz == 2000);
 }
 
 /**
@@ -220,7 +225,8 @@ static void test_set_polarity_normal(void) {
 }
 
 /**
- * T16: pwm_set_polarity(18, PWM_POLARITY_INVERTED) after init returns PWM_SUCCESS.
+ * T16: pwm_set_polarity(18, PWM_POLARITY_INVERTED) after init returns PWM_SUCCESS and
+ * updates shadow state — status.polarity must reflect the new polarity value.
  */
 static void test_set_polarity_inverted(void) {
     stub_reset();
@@ -229,6 +235,9 @@ static void test_set_polarity_inverted(void) {
     assert(pwm_init(18, 1000) == PWM_SUCCESS);
     int result = pwm_set_polarity(18, PWM_POLARITY_INVERTED);
     assert(result == PWM_SUCCESS);
+    pwm_status_t status;
+    assert(pwm_get_status(18, &status) == PWM_SUCCESS);
+    assert(status.polarity == PWM_POLARITY_INVERTED);
 }
 
 /**
@@ -375,8 +384,15 @@ static void test_get_chip_channel_null_fails(void) {
     stub_reset();
     pwm_reset_state_for_testing();
 
+    int chip, channel;
     int result = pwm_get_chip_channel(18, NULL, NULL);
     assert(result == PWM_ERROR_INVALID_PARAM);
+    result = pwm_get_chip_channel(18, NULL, &channel);
+    assert(result == PWM_ERROR_INVALID_PARAM);
+    result = pwm_get_chip_channel(18, &chip, NULL);
+    assert(result == PWM_ERROR_INVALID_PARAM);
+    (void)chip;    /* output only; value discarded — suppress -Wunused warnings */
+    (void)channel;
 }
 
 /**
@@ -672,6 +688,81 @@ static void test_set_frequency_reenable_fails_after_period_write(void) {
     stub_set_write_fail_on("/period", PWM_ERROR_IO);
     int result = pwm_set_frequency(18, 2000);
     assert(result == PWM_ERROR_IO);
+    assert(pwm_is_enabled(18) == false);
+}
+
+/**
+ * T47: pwm_deinit(18) propagates the error when the unexport sysfs write fails.
+ * The state is freed regardless; the caller receives the unexport error code.
+ * Verified by confirming GPIO 12 (same chip/channel as GPIO 18 on Pi 1-4) can
+ * be initialised after the failed deinit — proving the slot was released.
+ */
+static void test_deinit_unexport_fail_propagates(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    stub_set_write_fail_on("/unexport", PWM_ERROR_IO);
+    int result = pwm_deinit(18);
+    assert(result == PWM_ERROR_IO);
+    /* State slot must be freed even though unexport failed. */
+    assert(pwm_init(12, 1000) == PWM_SUCCESS);
+}
+
+/**
+ * T48: pwm_set_polarity(18, PWM_POLARITY_INVERTED) returns an error when both
+ * the polarity write and the subsequent re-enable write fail.
+ *
+ * Mirrors T46 for pwm_set_polarity.
+ *
+ * Setup:
+ *   stub_set_write_fail_after("/enable", PWM_ERROR_IO, 1) — lets the first
+ *   /enable write (disable step) succeed, then fails the second (re-enable).
+ *   stub_set_write_fail_on("/polarity", PWM_ERROR_IO) — fails the polarity write,
+ *   triggering the re-enable attempt that then also fails.
+ *
+ * Both mechanisms use independent slots and may be armed simultaneously.
+ */
+static void test_set_polarity_reenable_fails_after_polarity_write(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    stub_set_write_fail_after("/enable", PWM_ERROR_IO, 1);
+    stub_set_write_fail_on("/polarity", PWM_ERROR_IO);
+    int result = pwm_set_polarity(18, PWM_POLARITY_INVERTED);
+    assert(result == PWM_ERROR_IO);
+    assert(pwm_is_enabled(18) == false);
+}
+
+/**
+ * T49: pwm_init(18, 1000) returns PWM_ERROR_IO when the export sysfs write fails.
+ * The write to pwmchipN/export is the first I/O step in pwm_export(); failure
+ * propagates directly to pwm_init() without entering the poll loop.
+ */
+static void test_init_fails_on_export_write(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    stub_set_write_fail_on("/export", PWM_ERROR_IO);
+    int result = pwm_init(18, 1000);
+    assert(result == PWM_ERROR_IO);
+}
+
+/**
+ * T50: pwm_init(18, 1000) returns PWM_ERROR_HARDWARE when all state slots are full.
+ * pwm_fill_channels_for_testing() pre-fills every g_pwm_channels slot with a
+ * fictional pin (gpio_pin = 100..107, chip=0, ch=1).  GPIO 18 maps to ch=0,
+ * so the conflict check passes, but pwm_alloc_state() finds no free slot and
+ * returns NULL, causing pwm_init() to return PWM_ERROR_HARDWARE.
+ */
+static void test_init_fails_when_all_slots_full(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+    pwm_fill_channels_for_testing();
+
+    int result = pwm_init(18, 1000);
+    assert(result == PWM_ERROR_HARDWARE);
 }
 
 /* ============================================================
@@ -679,11 +770,6 @@ static void test_set_frequency_reenable_fails_after_period_write(void) {
  * ============================================================ */
 
 int main(void) {
-    /* Known gap: PWM_ERROR_HARDWARE (slot exhaustion at MAX_PWM_CHANNELS=8)
-     * is not tested. The Pi 1-4 stub map provides only 2 distinct chip/channel
-     * pairs, making it impossible to exhaust 8 slots without extending the stub.
-     * Tracked as a future improvement. */
-
     RUN(test_init_gpio18_succeeds);
     RUN(test_init_gpio13_succeeds);
     RUN(test_init_conflict_gpio12_after_gpio18);
@@ -730,7 +816,11 @@ int main(void) {
     RUN(test_set_frequency_fails_on_disable);
     RUN(test_set_polarity_fails_on_disable);
     RUN(test_set_frequency_reenable_fails_after_period_write);
+    RUN(test_set_polarity_reenable_fails_after_polarity_write);
+    RUN(test_deinit_unexport_fail_propagates);
+    RUN(test_init_fails_on_export_write);
+    RUN(test_init_fails_when_all_slots_full);
 
-    printf("\nAll 46 tests passed.\n");
+    printf("\nAll %d tests passed.\n", g_tests_run);
     return 0;
 }

--- a/tests/test_pwm_hal.c
+++ b/tests/test_pwm_hal.c
@@ -142,7 +142,7 @@ static void test_pi5_pin_map(void) {
     int chip = -1, channel = -1;
     int result = pwm_get_chip_channel(18, &chip, &channel);
 
-    assert(result  == PWM_SUCCESS);
+    assert(result == PWM_SUCCESS);
     assert(chip    == 2);
     assert(channel == 0);
 }
@@ -222,7 +222,7 @@ static void test_set_polarity_normal(void) {
 /**
  * T16: pwm_set_polarity(18, PWM_POLARITY_INVERTED) after init returns PWM_SUCCESS.
  */
-static void test_set_polarity_inversed(void) {
+static void test_set_polarity_inverted(void) {
     stub_reset();
     pwm_reset_state_for_testing();
 
@@ -604,6 +604,76 @@ static void test_set_frequency_fails_on_duty_write(void) {
     assert(result == PWM_ERROR_IO);
 }
 
+/**
+ * T43: pwm_init(18, PWM_MAX_FREQUENCY_HZ) returns PWM_SUCCESS.
+ * At 100 MHz the period is 10 ns (1,000,000,000 / 100,000,000 = 10).
+ */
+static void test_init_max_freq_succeeds(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    int result = pwm_init(18, PWM_MAX_FREQUENCY_HZ);
+    assert(result == PWM_SUCCESS);
+
+    pwm_status_t status;
+    assert(pwm_get_status(18, &status) == PWM_SUCCESS);
+    assert(status.period_ns == 10);
+    assert(status.frequency_hz == PWM_MAX_FREQUENCY_HZ);
+}
+
+/**
+ * T44: pwm_set_frequency(18, 2000) returns PWM_ERROR_IO when the disable
+ * write to /enable fails.  Failure is injected after a successful init so
+ * that the fault fires on the first /enable write inside pwm_set_frequency.
+ */
+static void test_set_frequency_fails_on_disable(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    stub_set_write_fail_on("/enable", PWM_ERROR_IO);
+    int result = pwm_set_frequency(18, 2000);
+    assert(result == PWM_ERROR_IO);
+}
+
+/**
+ * T45: pwm_set_polarity(18, PWM_POLARITY_INVERTED) returns PWM_ERROR_IO when
+ * the disable write to /enable fails.  Failure is injected after a successful
+ * init so that the fault fires on the first /enable write in pwm_set_polarity.
+ */
+static void test_set_polarity_fails_on_disable(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    stub_set_write_fail_on("/enable", PWM_ERROR_IO);
+    int result = pwm_set_polarity(18, PWM_POLARITY_INVERTED);
+    assert(result == PWM_ERROR_IO);
+}
+
+/**
+ * T46: pwm_set_frequency(18, 2000) returns an error when both the period write
+ * and the subsequent re-enable write fail.
+ *
+ * Setup:
+ *   stub_set_write_fail_after("/enable", PWM_ERROR_IO, 1) — lets the first
+ *   /enable write (disable step) succeed, then fails the second (re-enable).
+ *   stub_set_write_fail_on("/period", PWM_ERROR_IO) — fails the period write,
+ *   triggering the re-enable attempt that then also fails.
+ *
+ * Both mechanisms use independent slots and may be armed simultaneously.
+ */
+static void test_set_frequency_reenable_fails_after_period_write(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    stub_set_write_fail_after("/enable", PWM_ERROR_IO, 1);
+    stub_set_write_fail_on("/period", PWM_ERROR_IO);
+    int result = pwm_set_frequency(18, 2000);
+    assert(result == PWM_ERROR_IO);
+}
+
 /* ============================================================
  * Main
  * ============================================================ */
@@ -629,7 +699,7 @@ int main(void) {
     RUN(test_init_invalid_pin);
     RUN(test_set_frequency_valid);
     RUN(test_set_polarity_normal);
-    RUN(test_set_polarity_inversed);
+    RUN(test_set_polarity_inverted);
     RUN(test_get_status_after_init);
     RUN(test_is_enabled_after_init);
     RUN(test_is_enabled_before_init);
@@ -656,7 +726,11 @@ int main(void) {
     RUN(test_get_status_before_init_fails);
     RUN(test_write_fails_on_sysfs_io);
     RUN(test_set_frequency_fails_on_duty_write);
+    RUN(test_init_max_freq_succeeds);
+    RUN(test_set_frequency_fails_on_disable);
+    RUN(test_set_polarity_fails_on_disable);
+    RUN(test_set_frequency_reenable_fails_after_period_write);
 
-    printf("\nAll 42 tests passed.\n");
+    printf("\nAll 46 tests passed.\n");
     return 0;
 }


### PR DESCRIPTION
# Pull Request

## Description

Closes #118, closes #119. Adds a comprehensive C unit test suite for the lgpio PWM HAL using a link-seam architecture that enables native (non-hardware) testing. Also enforces pylint and mypy in CI for all Python modules.

**Two root-cause fixes:**
- `BuildSources` was passed a file path instead of a directory, causing `undefined reference to 'pwm_write'` at link time (#118)
- `pwm_init()` accessed `g_pwm_channels[]` before `pwm_init_state()` zeroed it, causing a false `PWM_ERROR_BUSY` on first use of GPIO 18/19 (#119)

**New test infrastructure:**
- `pwm-hal-sysfs.c` / `pwm-hal-internal.h` — sysfs I/O extracted behind a link-seam interface
- `tests/stubs/pwm-hal-sysfs-stub.c` — in-memory stub replacing the production sysfs layer in test builds
- `tests/test_pwm_hal.c` — 50 C unit tests (init/deinit, conflict detection, pin validation, frequency/polarity setters, status query, boundary values, slot exhaustion, export timeout simulation)
- `CMakeLists.txt` — native CMake build for host-side C tests

**CI additions:**
- `cpp-tests` job in `examples.yml`: builds and runs PWM HAL C tests on ubuntu-latest via CMake + ctest
- `tests.yml` lint job now enforces pylint (`.pylintrc`) and mypy across all four Python modules
- Build matrix extended with `lgpio-pwm-fade` and `lgpio-pwm-servo` examples

**AI assistance:** This PR was developed with Claude (Sonnet 4.6) assistance. All code has been reviewed, understood, and tested. CI passes fully green (Tests + Examples workflows). No AI co-author trailers present.

## Type of Change

- [x] [FIX] Bug fix (non-breaking change which fixes an issue)
- [x] [TEST] Test update
- [x] [BUILD] Build/CI configuration change

## Related Issues

Fixes #118
Fixes #119

## Checklist

### Testing

- [x] I have tested my changes locally
- [x] I have built all examples successfully
- [x] I have tested on target hardware (if applicable)
- [x] All CI/CD checks pass
- [x] I have tested both 32-bit and 64-bit builds (if applicable)

### Code Quality

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly
- [x] I have updated CONTRIBUTING.md if needed
- [x] I have updated the README.md if needed
- [ ] I have added or updated board definitions if needed
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) specification

### Framework Changes (if applicable)

- [x] I have tested the framework with examples
- [x] I have verified cross-compilation works
- [x] I have updated framework documentation
- [ ] I have tested on multiple Pi models (if applicable)

### AI-Assisted Contributions (if applicable)

- [x] I have disclosed the AI tool(s) used and the scope of assistance in the description above
- [x] I have reviewed and understand all AI-generated code in this PR
- [x] I have noted the degree of testing (untested / lightly tested / fully tested)
- [x] AI `Co-Authored-By:` commit trailers have been removed before submitting
- [ ] If hardware was involved, I have noted whether it was tested on real hardware or build-only

## Test Results

### Build Test Results

```
Tests workflow:    ✅ completed success (1m 40s)
Examples workflow: ✅ completed success (2m 30s)
```

C unit tests (50 tests via CMake + ctest): all pass on ubuntu-latest.
Python tests + lint + mypy: all pass across Python 3.9 / 3.10 / 3.11 / 3.12 on ubuntu/macos/windows.

## Additional Notes

The link-seam pattern isolates all `/sys/class/pwm` I/O in `pwm-hal-sysfs.c`. The stub (`tests/stubs/pwm-hal-sysfs-stub.c`) replaces it at link time for unit tests, tracking export state in-memory. The `UNIT_TESTING` preprocessor guard exposes test-only helpers (`pwm_reset_state_for_testing`, `pwm_fill_channels_for_testing`) without polluting the production build.

## Breaking Changes

None. All public C API signatures in `pwm-hal.h` are unchanged. No PlatformIO target or board definition changed. This is a patch release.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**