### PR TITLE
feat(lgpio)!: add pwm_sample_hardware, rename pwm_get_status to pwm_get_state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ development workflow, and common gotchas.
 cross-compilation and deployment of C/C++ applications for Linux ARM single-board
 computers (Raspberry Pi, Orange Pi, BeagleBone, Radxa, Khadas, Arduino Uno Q).
 
-**Version:** 1.9.x | **License:** Apache 2.0
+**Version:** 2.0.x | **License:** Apache 2.0
 
 ---
 
@@ -32,7 +32,7 @@ platform-linux_arm/
 ├── tests/                   # Python unit tests (pytest) for builder scripts
 │                            #   and C unit tests (CMake/ctest) for framework C code
 │   ├── test_platform.py     # pytest: builder script unit tests (83 tests)
-│   ├── test_pwm_hal.c       # ctest: PWM HAL C unit tests (50 tests, no hardware needed)
+│   ├── test_pwm_hal.c       # ctest: PWM HAL C unit tests (61 tests, no hardware needed)
 │   └── stubs/
 │       ├── pwm-hal-sysfs-stub.c  # Link-seam stub — replaces /sys/class/pwm/ with in-memory table
 │       └── pwm-hal-sysfs-stub.h  # Stub control API (stub_reset, stub_set_pi5, stub_set_export_delay)
@@ -294,7 +294,7 @@ Follows [Conventional Commits](https://www.conventionalcommits.org/).
 |----------|---------|-------------|
 | `examples.yml` | push, PR | Builds all 21 examples × {ubuntu, macos, windows} |
 | `tests.yml` | push, PR | Python pytest × {ubuntu, macos, windows} × Python {3.10, 3.11, 3.12} |
-| `examples.yml` | push, PR | C unit tests (CMake/ctest, 50 tests, ubuntu-latest) |
+| `examples.yml` | push, PR | C unit tests (CMake/ctest, 61 tests, ubuntu-latest) |
 | `release.yml` | tag push | Publishes platform package |
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **BREAKING** `pwm_get_status()` renamed to `pwm_get_state()` — formalises write-shadow as
+  the documented contract; name matches kernel/libgpiod convention (`state` = last-configured).
+  The `pwm_status_t` struct type is unchanged; only the function name differs.
+
+  **Migration guide**: replace every `pwm_get_status(pin, &s)` call with
+  `pwm_get_state(pin, &s)`. The `pwm_state_t` typedef (an alias for `pwm_status_t`) is
+  available as the preferred variable type when using `pwm_get_state()`, but `pwm_status_t`
+  remains valid. No struct members changed.
+
+  This is a **semver MAJOR** bump — downstream binaries linked against the old symbol will
+  not link; a source-level rename and recompile is required.
+
+### Changed
+
+### Added
+- `pwm_sample_hardware()` — reads live hardware registers via sysfs (4 reads: period,
+  duty_cycle, enable, polarity). Use when you need hardware truth rather than write-shadow.
+  Resolves #124.
+
 ### Fixed
 - lgpio framework: `BuildSources` was passed a file path instead of a directory, causing
   `undefined reference to 'pwm_write'` at link time (closes #118, reported and diagnosed
@@ -22,9 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   testing without Raspberry Pi hardware
 - lgpio PWM HAL: `tests/stubs/pwm-hal-sysfs-stub.c` — link-seam stub that replaces the
   production sysfs implementation in test builds; tracks export state in-memory
-- lgpio PWM HAL: `tests/test_pwm_hal.c` — 50 C unit tests covering init/deinit, conflict
-  detection, pin validation, frequency/polarity setters, status query, boundary values,
-  and export timeout simulation
+- lgpio PWM HAL: `tests/test_pwm_hal.c` — 50 C unit tests at seam extraction (T1–T50);
+  11 additional tests added in this release for `pwm_sample_hardware` (T51–T61, 61 total)
 - CI: `cpp-tests` job in `examples.yml` builds and runs the PWM HAL C test suite on
   ubuntu-latest via CMake + ctest
 - `.pylintrc` — project-specific pylint configuration enforced in CI lint job
@@ -231,7 +251,7 @@ Scope:
 - Hardware PWM support via Linux PWM subsystem (sysfs) for lgpio framework (#34)
   - Complete PWM HAL library (`framework-lgpio/pwm-hal.c`, `framework-lgpio/pwm-hal.h`)
   - Core API: `pwm_init()`, `pwm_write()`, `pwm_deinit()`
-  - Extended API: `pwm_set_frequency()`, `pwm_set_polarity()`, `pwm_get_status()`
+  - Extended API: `pwm_set_frequency()`, `pwm_set_polarity()`, `pwm_get_status()` (renamed `pwm_get_state()` in Unreleased)
   - Automatic Raspberry Pi model detection (Pi 1-4 vs Pi 5)
   - PWM permission setup scripts and systemd service
   - Comprehensive PWM setup guide (`docs/PWM_SETUP.md`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -349,7 +349,7 @@ Our GitHub Actions CI automatically tests:
 - Cross-compilation on Ubuntu (Linux x86_64)
 - `baremetal-hello` example for multiple boards
 - `lgpio-blink` example for multiple boards (32-bit and 64-bit)
-- PWM HAL C unit tests (50 test functions via CMake/ctest)
+- PWM HAL C unit tests (61 test functions via CMake/ctest)
 
 Make sure your changes pass CI before submitting a PR.
 

--- a/docs/PWM_SETUP.md
+++ b/docs/PWM_SETUP.md
@@ -92,11 +92,13 @@ Pi 5 has additional PWM channels via pwmchip3 (GPIO 2, 3) - future support plann
 PWM must be enabled in the device tree:
 
 **For Pi 1-4**, edit `/boot/config.txt`:
+
 ```bash
 sudo nano /boot/config.txt
 ```
 
 **For Pi 5**, edit `/boot/firmware/config.txt`:
+
 ```bash
 sudo nano /boot/firmware/config.txt
 ```
@@ -105,24 +107,25 @@ Add one of the following overlays:
 
 #### Single Channel (GPIO 18)
 
-```
+```ini
 dtoverlay=pwm,pin=18,func=2
 ```
 
 #### Dual Channel (GPIO 18 + 19)
 
-```
+```ini
 dtoverlay=pwm-2chan,pin=18,func=2,pin2=19,func2=2
 ```
 
 #### Custom GPIO Pins
 
-```
+```ini
 dtoverlay=pwm,pin=12,func=4     # GPIO 12 (ALT0)
 dtoverlay=pwm,pin=13,func=4     # GPIO 13 (ALT0)
 ```
 
 **Important**: Reboot after making changes:
+
 ```bash
 sudo reboot
 ```
@@ -132,17 +135,20 @@ sudo reboot
 Check if PWM hardware is detected:
 
 **Pi 1-4**:
+
 ```bash
 ls /sys/class/pwm/pwmchip0
 ```
 
 **Pi 5**:
+
 ```bash
 ls /sys/class/pwm/pwmchip2
 ```
 
 Expected output:
-```
+
+```text
 device  export  npwm  power  subsystem  uevent  unexport
 ```
 
@@ -205,28 +211,32 @@ Device tree overlays configure hardware peripherals at boot time. PWM overlays:
 
 #### Overlay Parameters
 
-```
+```ini
 dtoverlay=pwm[,OPTIONS]
 ```
 
 Options:
+
 - `pin=N` - GPIO pin number (12, 13, 18, or 19)
 - `func=N` - Alternate function (2 for GPIO 18/19, 4 for GPIO 12/13)
 
 #### Configuration Examples
 
 **LED on GPIO 18**:
-```
+
+```ini
 dtoverlay=pwm,pin=18,func=2
 ```
 
 **Two LEDs on GPIO 18 and 19**:
-```
+
+```ini
 dtoverlay=pwm-2chan,pin=18,func=2,pin2=19,func2=2
 ```
 
 **Motor on GPIO 12**:
-```
+
+```ini
 dtoverlay=pwm,pin=12,func=4
 ```
 
@@ -235,6 +245,7 @@ dtoverlay=pwm,pin=12,func=4
 #### Manual Setup
 
 Export PWM channel:
+
 ```bash
 # Pi 1-4 (pwmchip0, channel 0)
 echo 0 | sudo tee /sys/class/pwm/pwmchip0/export
@@ -244,6 +255,7 @@ echo 0 | sudo tee /sys/class/pwm/pwmchip2/export
 ```
 
 Set permissions:
+
 ```bash
 # Pi 1-4
 sudo chown -R root:gpio /sys/class/pwm/pwmchip0/pwm0
@@ -255,6 +267,7 @@ sudo chmod -R ug+rw /sys/class/pwm/pwmchip2/pwm0
 ```
 
 Add user to gpio group:
+
 ```bash
 sudo usermod -a -G gpio $USER
 # Log out and back in for changes to take effect
@@ -269,6 +282,7 @@ sudo ./scripts/setup-pwm-perms.sh
 ```
 
 Script features:
+
 - Auto-detects Pi model (pwmchip0 vs pwmchip2)
 - Exports multiple channels (default: 2)
 - Sets group ownership (default: gpio)
@@ -276,6 +290,7 @@ Script features:
 - Validates configuration
 
 Options:
+
 ```bash
 sudo ./scripts/setup-pwm-perms.sh --chip 0      # Force pwmchip0 (Pi 1-4)
 sudo ./scripts/setup-pwm-perms.sh --chip 2      # Force pwmchip2 (Pi 5)
@@ -288,6 +303,7 @@ sudo ./scripts/setup-pwm-perms.sh --help        # Show all options
 Automatically setup PWM permissions on boot:
 
 **Install service**:
+
 ```bash
 sudo cp scripts/platformio-pwm.service /etc/systemd/system/
 sudo systemctl enable platformio-pwm.service
@@ -295,16 +311,19 @@ sudo systemctl start platformio-pwm.service
 ```
 
 **Check status**:
+
 ```bash
 sudo systemctl status platformio-pwm.service
 ```
 
 **View logs**:
+
 ```bash
 sudo journalctl -u platformio-pwm.service
 ```
 
 **Uninstall service**:
+
 ```bash
 sudo systemctl stop platformio-pwm.service
 sudo systemctl disable platformio-pwm.service
@@ -324,14 +343,17 @@ int pwm_init(int pin, uint32_t freq_hz);
 ```
 
 **Parameters**:
+
 - `pin` - GPIO pin number (12, 13, 18, or 19)
 - `freq_hz` - Frequency in Hz (1 Hz to 100 MHz)
 
 **Returns**:
+
 - `PWM_SUCCESS` (0) on success
 - Error code on failure (see [Error Codes](#error-codes))
 
 **Example**:
+
 ```c
 // Initialize GPIO 18 at 1 kHz
 int result = pwm_init(18, 1000);
@@ -351,14 +373,17 @@ int pwm_write(int pin, float duty_cycle_percent);
 ```
 
 **Parameters**:
+
 - `pin` - GPIO pin number
 - `duty_cycle_percent` - Duty cycle (0.0 to 100.0%)
 
 **Returns**:
+
 - `PWM_SUCCESS` (0) on success
 - Error code on failure
 
 **Example**:
+
 ```c
 // Set 75% duty cycle (75% power)
 pwm_write(18, 75.0);
@@ -381,13 +406,16 @@ int pwm_deinit(int pin);
 ```
 
 **Parameters**:
+
 - `pin` - GPIO pin number
 
 **Returns**:
+
 - `PWM_SUCCESS` (0) on success
 - Error code on failure
 
 **Example**:
+
 ```c
 // Cleanup when done
 pwm_deinit(18);
@@ -406,14 +434,17 @@ int pwm_set_frequency(int pin, uint32_t freq_hz);
 ```
 
 **Parameters**:
+
 - `pin` - GPIO pin number
 - `freq_hz` - New frequency in Hz
 
 **Returns**:
+
 - `PWM_SUCCESS` (0) on success
 - Error code on failure
 
 **Example**:
+
 ```c
 // Change frequency to 5 kHz
 pwm_set_frequency(18, 5000);
@@ -432,14 +463,17 @@ int pwm_set_polarity(int pin, pwm_polarity_t polarity);
 ```
 
 **Parameters**:
+
 - `pin` - GPIO pin number
 - `polarity` - `PWM_POLARITY_NORMAL` or `PWM_POLARITY_INVERTED`
 
 **Returns**:
+
 - `PWM_SUCCESS` (0) on success
 - Error code on failure
 
 **Example**:
+
 ```c
 // Normal polarity (high = active)
 pwm_set_polarity(18, PWM_POLARITY_NORMAL);
@@ -452,26 +486,29 @@ pwm_set_polarity(18, PWM_POLARITY_INVERTED);
 
 ---
 
-#### pwm_get_status()
+#### pwm_get_state()
 
 Query current PWM status and configuration.
 
 ```c
-int pwm_get_status(int pin, pwm_status_t *status);
+int pwm_get_state(int pin, pwm_status_t *status);
 ```
 
 **Parameters**:
+
 - `pin` - GPIO pin number
 - `status` - Pointer to `pwm_status_t` structure
 
 **Returns**:
+
 - `PWM_SUCCESS` (0) on success
 - Error code on failure
 
 **Example**:
+
 ```c
 pwm_status_t status;
-if (pwm_get_status(18, &status) == PWM_SUCCESS) {
+if (pwm_get_state(18, &status) == PWM_SUCCESS) {
     printf("Frequency: %u Hz\n", status.frequency_hz);
     printf("Duty Cycle: %.1f%%\n", status.duty_cycle_percent);
     printf("Enabled: %s\n", status.is_enabled ? "yes" : "no");
@@ -479,6 +516,7 @@ if (pwm_get_status(18, &status) == PWM_SUCCESS) {
 ```
 
 **Status Structure**:
+
 ```c
 typedef struct {
     int gpio_pin;              // GPIO pin number
@@ -496,6 +534,51 @@ typedef struct {
 
 ---
 
+#### pwm_sample_hardware()
+
+Read live hardware state directly from sysfs registers.
+
+```c
+int pwm_sample_hardware(int pin, pwm_status_t *status);
+```
+
+**Parameters**:
+
+- `pin` - GPIO pin number
+- `status` - Pointer to `pwm_status_t` structure
+
+**Returns**:
+
+- `PWM_SUCCESS` (0) on success
+- `PWM_ERROR_INVALID_PARAM` if `status` is NULL
+- `PWM_ERROR_NOT_EXPORTED` if pin not initialized
+- `PWM_ERROR_IO` on sysfs read failure or malformed data
+
+**Example**:
+
+```c
+pwm_status_t hw_state;
+if (pwm_sample_hardware(18, &hw_state) == PWM_SUCCESS) {
+    printf("Live HW frequency: %u Hz\n", hw_state.frequency_hz);
+    printf("Live HW duty cycle: %.1f%%\n", hw_state.duty_cycle_percent);
+}
+```
+
+**Note**: Performs 4 sysfs reads (period, duty_cycle, enable, polarity) on each call. More
+expensive than `pwm_get_state()`, which reads from the write-shadow cache. Use
+`pwm_sample_hardware()` when you need to verify actual hardware state, e.g., after a
+suspected hardware reset or for diagnostic tooling.
+
+**Note**: The 4 reads are **not atomic** — if another process modifies the PWM channel
+between reads, the returned struct may be an inconsistent snapshot (e.g., period from before
+a frequency change, duty_cycle from after). Suitable for diagnostics and verification; do
+not rely on this function for real-time synchronisation.
+
+**Note**: `status.frequency_hz` is derived via integer division (`1 GHz / period_ns`) and
+may differ slightly from the value passed to `pwm_init()` due to rounding.
+
+---
+
 #### pwm_is_enabled()
 
 Check if PWM channel is enabled.
@@ -505,13 +588,16 @@ bool pwm_is_enabled(int pin);
 ```
 
 **Parameters**:
+
 - `pin` - GPIO pin number
 
 **Returns**:
+
 - `true` if enabled
 - `false` if disabled or not initialized
 
 **Example**:
+
 ```c
 if (pwm_is_enabled(18)) {
     printf("PWM is active\n");
@@ -531,12 +617,15 @@ const char* pwm_error_string(pwm_error_t error);
 ```
 
 **Parameters**:
+
 - `error` - Error code
 
 **Returns**:
+
 - Pointer to static error message string
 
 **Example**:
+
 ```c
 int result = pwm_init(18, 1000);
 if (result != PWM_SUCCESS) {
@@ -555,13 +644,16 @@ bool pwm_pin_is_valid(int pin);
 ```
 
 **Parameters**:
+
 - `pin` - GPIO pin number
 
 **Returns**:
+
 - `true` if pin supports PWM
 - `false` otherwise
 
 **Example**:
+
 ```c
 if (!pwm_pin_is_valid(18)) {
     printf("GPIO 18 does not support PWM\n");
@@ -579,15 +671,18 @@ int pwm_get_chip_channel(int pin, int *chip, int *channel);
 ```
 
 **Parameters**:
+
 - `pin` - GPIO pin number
 - `chip` - Pointer to store chip number (output)
 - `channel` - Pointer to store channel number (output)
 
 **Returns**:
+
 - `PWM_SUCCESS` (0) on success
 - `PWM_ERROR_INVALID_PIN` if not a PWM pin
 
 **Example**:
+
 ```c
 int chip, channel;
 if (pwm_get_chip_channel(18, &chip, &channel) == PWM_SUCCESS) {
@@ -642,8 +737,8 @@ int main() {
     pwm_write(pin, 50.0);
 
     // Query status
-    pwm_status_t status;
-    pwm_get_status(pin, &status);
+    pwm_state_t status;
+    pwm_get_state(pin, &status);
     printf("Frequency: %u Hz\n", status.frequency_hz);
 
     // Cleanup
@@ -658,11 +753,13 @@ int main() {
 ### Permission denied (PWM_ERROR_PERMISSION)
 
 **Symptoms**:
-```
+
+```text
 ERROR: Failed to initialize PWM: Permission denied (run setup-pwm-perms.sh)
 ```
 
 **Causes**:
+
 1. PWM permissions not setup
 2. User not in gpio group
 3. Wrong file ownership
@@ -670,17 +767,20 @@ ERROR: Failed to initialize PWM: Permission denied (run setup-pwm-perms.sh)
 **Solutions**:
 
 1. Run setup script:
+
    ```bash
    sudo ./scripts/setup-pwm-perms.sh
    ```
 
 2. Add user to gpio group:
+
    ```bash
    sudo usermod -a -G gpio $USER
    # Log out and back in
    ```
 
 3. Manual permission fix:
+
    ```bash
    # Pi 1-4
    sudo chown -R root:gpio /sys/class/pwm/pwmchip0/pwm0
@@ -696,11 +796,13 @@ ERROR: Failed to initialize PWM: Permission denied (run setup-pwm-perms.sh)
 ### PWM channel not exported (PWM_ERROR_NOT_EXPORTED)
 
 **Symptoms**:
-```
+
+```text
 ERROR: Failed to initialize PWM: PWM channel not exported
 ```
 
 **Causes**:
+
 1. Device tree overlay not loaded
 2. Wrong pwmchip for Pi model
 3. Kernel PWM subsystem disabled
@@ -708,6 +810,7 @@ ERROR: Failed to initialize PWM: PWM channel not exported
 **Solutions**:
 
 1. Check device tree overlay:
+
    ```bash
    # Pi 1-4
    grep pwm /boot/config.txt
@@ -717,6 +820,7 @@ ERROR: Failed to initialize PWM: PWM channel not exported
    ```
 
 2. Add overlay if missing:
+
    ```bash
    # Pi 1-4
    echo "dtoverlay=pwm,pin=18,func=2" | sudo tee -a /boot/config.txt
@@ -728,6 +832,7 @@ ERROR: Failed to initialize PWM: PWM channel not exported
    ```
 
 3. Verify pwmchip exists:
+
    ```bash
    # Pi 1-4
    ls /sys/class/pwm/pwmchip0
@@ -737,6 +842,7 @@ ERROR: Failed to initialize PWM: PWM channel not exported
    ```
 
 4. Check kernel config:
+
    ```bash
    zcat /proc/config.gz | grep PWM
    # Should see: CONFIG_PWM=y, CONFIG_PWM_BCM2835=y
@@ -747,7 +853,8 @@ ERROR: Failed to initialize PWM: PWM channel not exported
 ### GPIO pin does not support PWM (PWM_ERROR_INVALID_PIN)
 
 **Symptoms**:
-```
+
+```text
 ERROR: GPIO 17 does not support PWM
 Valid PWM pins: 12, 13, 18, 19
 ```
@@ -763,11 +870,13 @@ Use a valid PWM pin: 12, 13, 18, or 19
 ### PWM channel already in use (PWM_ERROR_BUSY)
 
 **Symptoms**:
-```
+
+```text
 ERROR: Failed to initialize PWM: PWM channel already in use
 ```
 
 **Causes**:
+
 1. Another process using the same PWM channel
 2. GPIO pin conflict (12/18 share PWM0, 13/19 share PWM1)
 3. Channel already exported by another program
@@ -775,17 +884,20 @@ ERROR: Failed to initialize PWM: PWM channel already in use
 **Solutions**:
 
 1. Check for other processes:
+
    ```bash
    sudo lsof | grep pwm
    ps aux | grep lgpio
    ```
 
 2. Kill competing processes:
+
    ```bash
    sudo killall lgpio-pwm-fade
    ```
 
 3. Unexport and re-export channel:
+
    ```bash
    # Pi 1-4
    echo 0 | sudo tee /sys/class/pwm/pwmchip0/unexport
@@ -805,6 +917,7 @@ ERROR: Failed to initialize PWM: PWM channel already in use
 ### LED not turning on/off
 
 **Causes**:
+
 1. LED polarity reversed
 2. Resistor value too high
 3. GPIO pin not configured
@@ -817,12 +930,14 @@ ERROR: Failed to initialize PWM: PWM channel already in use
    - Short leg (cathode, flat side) to GND
 
 2. Test with known working frequency:
+
    ```c
    pwm_init(18, 1000);
    pwm_write(18, 100.0);  // Full brightness
    ```
 
 3. Test GPIO with non-PWM code:
+
    ```bash
    # Use lgpio-blink example to verify GPIO works
    cd examples/lgpio-blink
@@ -838,6 +953,7 @@ ERROR: Failed to initialize PWM: PWM channel already in use
 ### LED flickering or unstable
 
 **Causes**:
+
 1. Frequency too low
 2. Duty cycle at extreme values (0% or 100%)
 3. Power supply noise
@@ -846,11 +962,13 @@ ERROR: Failed to initialize PWM: PWM channel already in use
 **Solutions**:
 
 1. Increase frequency:
+
    ```c
    pwm_init(18, 5000);  // 5 kHz instead of 1 kHz
    ```
 
 2. Avoid extreme duty cycles:
+
    ```c
    // Use 1% instead of 0%
    pwm_write(18, 1.0);
@@ -869,6 +987,7 @@ ERROR: Failed to initialize PWM: PWM channel already in use
 ### Frequency limited or duty cycle clamped
 
 **Symptoms**:
+
 - Cannot set frequency above certain value
 - Duty cycle limited to specific range
 
@@ -876,6 +995,7 @@ ERROR: Failed to initialize PWM: PWM channel already in use
 Hardware limitations of PWM peripheral.
 
 **Raspberry Pi PWM Limits**:
+
 - Frequency: 1 Hz to ~100 MHz (practical: 1 Hz to 10 MHz)
 - Duty cycle: 0.0% to 100.0%
 - Resolution: Dependent on frequency (higher frequency = lower resolution)
@@ -1085,11 +1205,13 @@ For fine control, use lower frequencies.
 | Setup | Device tree + permissions | None (immediate) |
 
 Use hardware PWM (this HAL) when:
+
 - Precise timing required (servo, motor)
 - Low CPU usage desired
 - High frequency needed
 
 Use software PWM (lgpio) when:
+
 - Need many PWM outputs
 - Quick prototyping
 - Imprecise timing acceptable
@@ -1126,12 +1248,14 @@ See [LGPIO_SETUP.md](LGPIO_SETUP.md) for detailed cross-compilation instructions
 ### Documentation
 
 - [Linux PWM Subsystem](https://www.kernel.org/doc/Documentation/pwm.txt) - Kernel PWM documentation
+<!-- markdownlint-disable-next-line MD013 -->
 - [Raspberry Pi Device Tree Overlays](https://github.com/raspberrypi/firmware/blob/master/boot/overlays/README) - PWM overlay options
 - [sysfs PWM Guide](https://jumpnowtek.com/rpi/Using-the-Raspberry-Pi-Hardware-PWM-timers.html) - Practical PWM usage
 - [lgpio Documentation](http://abyz.me.uk/lg/lgpio.html) - lgpio library reference
 
 ### Hardware
 
+<!-- markdownlint-disable-next-line MD013 -->
 - [BCM2835 ARM Peripherals](https://www.raspberrypi.org/app/uploads/2012/02/BCM2835-ARM-Peripherals.pdf) - Pi 1-4 hardware (Chapter 9: PWM)
 - [BCM2711 Datasheet](https://datasheets.raspberrypi.com/bcm2711/bcm2711-peripherals.pdf) - Pi 4 hardware
 - [RP1 Datasheet](https://datasheets.raspberrypi.com/rp1/rp1-peripherals.pdf) - Pi 5 I/O controller
@@ -1154,10 +1278,12 @@ See [LGPIO_SETUP.md](LGPIO_SETUP.md) for detailed cross-compilation instructions
 
 1. Check [Troubleshooting](#troubleshooting) section
 2. Run diagnostics:
+
    ```bash
    sudo ./scripts/setup-pwm-perms.sh --verbose
    ```
-3. Search existing issues: https://github.com/sfo2001/platform-linux_arm/issues
+
+3. Search existing issues: <https://github.com/sfo2001/platform-linux_arm/issues>
 4. Create new issue with:
    - Raspberry Pi model
    - OS version (`cat /etc/os-release`)
@@ -1168,6 +1294,7 @@ See [LGPIO_SETUP.md](LGPIO_SETUP.md) for detailed cross-compilation instructions
 ### Contributing
 
 Contributions welcome! See [CONTRIBUTING.md](../CONTRIBUTING.md) for:
+
 - Development setup
 - Code style guidelines
 - Testing requirements

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -80,7 +80,7 @@ The `framework-lgpio/pwm-hal` library has a self-contained C unit test suite tha
 | Test target | `test_pwm_hal` |
 | Build system | CMake (out-of-source) |
 | Hardware required | None |
-| Tests | 50 unit tests |
+| Tests | 59 unit tests |
 
 ### Architecture
 

--- a/examples/lgpio-pwm-fade/README.md
+++ b/examples/lgpio-pwm-fade/README.md
@@ -21,12 +21,13 @@ Demonstrates hardware PWM control using the lgpio framework with PWM HAL for smo
 
 ### Wiring Diagram
 
-```
+```text
 Raspberry Pi GPIO 18 ----[220Ω]----[LED Anode (+, long leg)]
                                     [LED Cathode (-, short leg)]---- GND
 ```
 
 **Important**:
+
 - LED cathode (short leg, flat side) connects to GND
 - LED anode (long leg) connects through resistor to GPIO 18
 - Resistor can be on either side of the LED
@@ -40,7 +41,8 @@ Raspberry Pi GPIO 18 ----[220Ω]----[LED Anode (+, long leg)]
 | 18   | PWM0        | **Recommended** (conflicts with GPIO 12) |
 | 19   | PWM1        | Alternative (conflicts with GPIO 13) |
 
-**Note**: GPIO 12 and 18 share PWM0 channel. GPIO 13 and 19 share PWM1 channel. You cannot use both pins on the same channel simultaneously.
+**Note**: GPIO 12 and 18 share PWM0 channel. GPIO 13 and 19 share PWM1 channel.
+You cannot use both pins on the same channel simultaneously.
 
 ## Software Setup
 
@@ -49,26 +51,31 @@ Raspberry Pi GPIO 18 ----[220Ω]----[LED Anode (+, long leg)]
 Edit the boot configuration file:
 
 **For Pi 1-4**:
+
 ```bash
 sudo nano /boot/config.txt
 ```
 
 **For Pi 5**:
+
 ```bash
 sudo nano /boot/firmware/config.txt
 ```
 
 Add the following line:
-```
+
+```ini
 dtoverlay=pwm,pin=18,func=2
 ```
 
 For dual-channel PWM (both PWM0 and PWM1):
-```
+
+```ini
 dtoverlay=pwm-2chan,pin=18,func=2,pin2=19,func2=2
 ```
 
 Save and reboot:
+
 ```bash
 sudo reboot
 ```
@@ -76,12 +83,14 @@ sudo reboot
 ### 2. Setup PWM Permissions
 
 Run the permissions setup script:
+
 ```bash
 cd /path/to/platform-linux_arm
 sudo ./scripts/setup-pwm-perms.sh
 ```
 
 This script:
+
 - Exports PWM channels to userspace
 - Sets correct group ownership (gpio)
 - Applies read/write permissions
@@ -89,6 +98,7 @@ This script:
 ### 3. Install systemd Service (Optional)
 
 To automatically setup PWM permissions on boot:
+
 ```bash
 sudo cp scripts/platformio-pwm.service /etc/systemd/system/
 sudo systemctl enable platformio-pwm.service
@@ -138,6 +148,7 @@ pio run -e raspberrypi_4b_upload -t upload
 ### Basic Usage
 
 Run with default settings (GPIO 18, 1000 Hz):
+
 ```bash
 sudo ./lgpio-pwm-fade
 ```
@@ -145,6 +156,7 @@ sudo ./lgpio-pwm-fade
 ### Custom GPIO Pin
 
 Use GPIO 13 (PWM1) instead:
+
 ```bash
 sudo ./lgpio-pwm-fade 13
 ```
@@ -152,13 +164,14 @@ sudo ./lgpio-pwm-fade 13
 ### Custom Frequency
 
 Set frequency to 5000 Hz:
+
 ```bash
 sudo ./lgpio-pwm-fade 18 5000
 ```
 
 ## Expected Output
 
-```
+```text
 PWM LED Fade Example (lgpio framework with PWM HAL)
 ====================================================
 GPIO Pin: 18
@@ -191,6 +204,7 @@ The LED should smoothly fade in and out continuously.
 **Cause**: PWM permissions not setup correctly or user not in gpio group
 
 **Solution**:
+
 ```bash
 # Run setup script
 sudo ./scripts/setup-pwm-perms.sh
@@ -206,7 +220,9 @@ sudo usermod -a -G gpio $USER
 **Cause**: PWM device tree overlay not loaded
 
 **Solution**:
+
 1. Check overlay is in config.txt:
+
    ```bash
    # For Pi 1-4
    grep pwm /boot/config.txt
@@ -216,16 +232,19 @@ sudo usermod -a -G gpio $USER
    ```
 
 2. If missing, add:
-   ```
+
+   ```ini
    dtoverlay=pwm,pin=18,func=2
    ```
 
 3. Reboot:
+
    ```bash
    sudo reboot
    ```
 
 4. Verify pwmchip exists:
+
    ```bash
    # Pi 1-4
    ls /sys/class/pwm/pwmchip0
@@ -243,11 +262,14 @@ sudo usermod -a -G gpio $USER
 ### Error: PWM channel already in use
 
 **Cause**:
+
 - Another process is using the same PWM channel
 - GPIO 12/18 (PWM0) or GPIO 13/19 (PWM1) conflict
 
 **Solution**:
+
 1. Check for other processes:
+
    ```bash
    sudo lsof | grep pwm
    ```
@@ -257,6 +279,7 @@ sudo usermod -a -G gpio $USER
 ### LED Not Fading Smoothly
 
 **Possible causes**:
+
 1. **Wrong LED polarity**: Flip LED around
 2. **Frequency too low**: Try higher frequency (e.g., 5000 Hz)
 3. **Resistor value too high**: Use lower value resistor
@@ -292,7 +315,7 @@ cat /sys/class/pwm/pwmchip0/pwm0/enable
 
 - `pwm_init()` - Initialize hardware PWM
 - `pwm_write()` - Set duty cycle (brightness)
-- `pwm_get_status()` - Query PWM configuration
+- `pwm_get_state()` - Query PWM configuration
 - `pwm_deinit()` - Cleanup and release resources
 - `pwm_pin_is_valid()` - Validate GPIO pin
 - `pwm_error_string()` - Human-readable error messages
@@ -302,6 +325,7 @@ cat /sys/class/pwm/pwmchip0/pwm0/enable
 ### Experiment with Different Effects
 
 Modify fade parameters in the code:
+
 - Change `FADE_STEPS` for smoother/faster fading
 - Adjust `FADE_DELAY_MS` for fade speed
 - Modify `PWM_FREQUENCY` for different effects
@@ -309,6 +333,7 @@ Modify fade parameters in the code:
 ### Multiple LEDs
 
 Use both PWM channels simultaneously:
+
 ```bash
 # Terminal 1: GPIO 18 (PWM0)
 sudo ./lgpio-pwm-fade 18
@@ -320,6 +345,7 @@ sudo ./lgpio-pwm-fade 13
 ### Integration with Other Projects
 
 Include PWM HAL in your projects:
+
 ```c
 #include "pwm-hal.h"
 

--- a/examples/lgpio-pwm-fade/src/pwm_fade.c
+++ b/examples/lgpio-pwm-fade/src/pwm_fade.c
@@ -214,7 +214,7 @@ int main(int argc, char *argv[]) {
 
     // Get initial status
     pwm_status_t status;
-    if (pwm_get_status(gpio_pin, &status) == PWM_SUCCESS) {
+    if (pwm_get_state(gpio_pin, &status) == PWM_SUCCESS) {
         printf("PWM Status:\n");
         printf("  Chip: %d, Channel: %d\n", status.pwm_chip, status.pwm_channel);
         printf("  Enabled: %s\n", status.is_enabled ? "yes" : "no");

--- a/examples/lgpio-pwm-servo/src/servo_control.c
+++ b/examples/lgpio-pwm-servo/src/servo_control.c
@@ -311,7 +311,7 @@ int main(int argc, char *argv[]) {
 
     // Get PWM status
     pwm_status_t status;
-    if (pwm_get_status(gpio_pin, &status) == PWM_SUCCESS) {
+    if (pwm_get_state(gpio_pin, &status) == PWM_SUCCESS) {
         printf("\nPWM Status:\n");
         printf("  Chip: %d, Channel: %d\n", status.pwm_chip, status.pwm_channel);
         printf("  Frequency: %u Hz\n", status.frequency_hz);

--- a/framework-lgpio/pwm-hal-internal.h
+++ b/framework-lgpio/pwm-hal-internal.h
@@ -51,10 +51,9 @@ extern const pwm_pin_map_t g_pwm_pin_map_pi5[];
 int  pwm_sysfs_write(const char *path, const char *value);
 /**
  * Read a sysfs attribute into value (max_len bytes, NUL-terminated).
- * @todo(#124) Not yet called from pwm-hal.c — readback support is planned.
- * Stub and production implementations MUST provide this function regardless,
- * as it is part of the mandatory seam contract; a stub that omits it will
- * fail to link when #124 wires up the caller.
+ * Used by pwm_sample_hardware() to read live hardware state.
+ * Stub and production implementations MUST provide this function as it is
+ * part of the mandatory seam contract.
  */
 int  pwm_sysfs_read(const char *path, char *value, size_t max_len);
 /**

--- a/framework-lgpio/pwm-hal-sysfs.c
+++ b/framework-lgpio/pwm-hal-sysfs.c
@@ -47,7 +47,6 @@ void pwm_sysfs_sleep_ms(int ms) {
     usleep((useconds_t)ms * 1000);
 }
 
-/* @todo(#124): no callers yet — reserved for live readback */
 int pwm_sysfs_read(const char *path, char *value, size_t max_len) {
     int fd = open(path, O_RDONLY);
     if (fd < 0) {
@@ -85,7 +84,7 @@ const pwm_pin_map_t *pwm_get_pin_map(void) {
      * Pi 1–4 (single controller, pwmchip0 only).  Known limitation: this
      * detection can produce a false Pi 5 result if pwmchip2 is present for
      * another reason (e.g. a USB PWM adapter), or a false Pi 1–4 result if
-     * the Pi 5 pwm overlay is not loaded.  Tracked for improvement in #124.
+     * the Pi 5 pwm overlay is not loaded.
      */
     struct stat st;
     if (stat("/sys/class/pwm/pwmchip2", &st) == 0 && S_ISDIR(st.st_mode)) {

--- a/framework-lgpio/pwm-hal.c
+++ b/framework-lgpio/pwm-hal.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 
 /* ============================================================================
  * Internal Data Structures and Constants
@@ -548,10 +549,7 @@ int pwm_set_polarity(int pin, pwm_polarity_t polarity) {
     return PWM_SUCCESS;
 }
 
-/* TODO(#124): returns write-shadow state (last values set via this API), NOT live
- * hardware state.  pwm_sysfs_read is available but unwired — see issue for design
- * options (always-read-back, cache-invalidation, or document-as-mirror). */
-int pwm_get_status(int pin, pwm_status_t *status) {
+int pwm_get_state(int pin, pwm_state_t *status) {
     if (!status) {
         return PWM_ERROR_INVALID_PARAM;
     }
@@ -573,6 +571,94 @@ int pwm_get_status(int pin, pwm_status_t *status) {
     status->polarity = state->polarity;
     status->period_ns = 1000000000ULL / state->frequency_hz;
     status->duty_cycle_ns = (uint64_t)((double)status->period_ns * ((double)state->duty_cycle_percent / 100.0));
+
+    return PWM_SUCCESS;
+}
+
+int pwm_sample_hardware(int pin, pwm_state_t *status) {
+    char path[MAX_PATH_LEN];
+    char buf[MAX_VALUE_LEN];
+    int result;
+
+    if (!status) {
+        return PWM_ERROR_INVALID_PARAM;
+    }
+
+    pwm_channel_state_t* state = pwm_find_state(pin);
+    if (!state) {
+        return PWM_ERROR_NOT_EXPORTED;
+    }
+
+    snprintf(path, sizeof(path), "%s/pwmchip%d/pwm%d/period",
+             PWM_SYSFS_BASE, state->pwm_chip, state->pwm_channel);
+    result = pwm_sysfs_read(path, buf, sizeof(buf));
+    if (result != PWM_SUCCESS) {
+        return result;
+    }
+    char *end_ptr;
+    uint64_t period_ns = strtoull(buf, &end_ptr, 10);
+    if (end_ptr == buf || (*end_ptr != '\0' && *end_ptr != '\n') || period_ns == 0) {
+        return PWM_ERROR_IO;
+    }
+
+    snprintf(path, sizeof(path), "%s/pwmchip%d/pwm%d/duty_cycle",
+             PWM_SYSFS_BASE, state->pwm_chip, state->pwm_channel);
+    result = pwm_sysfs_read(path, buf, sizeof(buf));
+    if (result != PWM_SUCCESS) {
+        return result;
+    }
+    uint64_t duty_cycle_ns = strtoull(buf, &end_ptr, 10);
+    if (end_ptr == buf || (*end_ptr != '\0' && *end_ptr != '\n')) {
+        return PWM_ERROR_IO;
+    }
+
+    snprintf(path, sizeof(path), "%s/pwmchip%d/pwm%d/enable",
+             PWM_SYSFS_BASE, state->pwm_chip, state->pwm_channel);
+    result = pwm_sysfs_read(path, buf, sizeof(buf));
+    if (result != PWM_SUCCESS) {
+        return result;
+    }
+    int enable_val = 0;
+    if (sscanf(buf, "%d", &enable_val) != 1) {
+        return PWM_ERROR_IO;
+    }
+
+    snprintf(path, sizeof(path), "%s/pwmchip%d/pwm%d/polarity",
+             PWM_SYSFS_BASE, state->pwm_chip, state->pwm_channel);
+    result = pwm_sysfs_read(path, buf, sizeof(buf));
+    if (result != PWM_SUCCESS) {
+        return result;
+    }
+    /* kernel sysfs uses "inversed" (not "inverted") — see Documentation/driver-api/pwm.rst.
+     * Relies on pwm_sysfs_read() stripping the trailing '\n'; the production
+     * implementation (pwm-hal-sysfs.c) does this unconditionally. */
+    pwm_polarity_t polarity;
+    if (strcmp(buf, "normal") == 0) {
+        polarity = PWM_POLARITY_NORMAL;
+    } else if (strcmp(buf, "inversed") == 0) {
+        polarity = PWM_POLARITY_INVERTED;
+    } else {
+        return PWM_ERROR_IO;
+    }
+
+    /* Clamp raw duty_cycle_ns so the caller also sees a bounded nanosecond
+     * value, not just a bounded percentage.  A sysfs race could deliver a
+     * duty_cycle > period snapshot; cap it before storing. */
+    if (duty_cycle_ns > period_ns) duty_cycle_ns = period_ns;
+
+    status->gpio_pin          = state->gpio_pin;
+    status->pwm_chip          = state->pwm_chip;
+    status->pwm_channel       = state->pwm_channel;
+    status->is_exported       = state->is_exported;
+    status->period_ns         = period_ns;
+    status->duty_cycle_ns     = duty_cycle_ns;
+    status->is_enabled        = (enable_val != 0);
+    status->polarity          = polarity;
+    status->frequency_hz      = (uint32_t)(1000000000ULL / period_ns);
+    status->duty_cycle_percent = (float)((double)duty_cycle_ns / (double)period_ns * 100.0);
+    if (status->duty_cycle_percent > 100.0f) status->duty_cycle_percent = 100.0f;
+    /* defensive: duty_cycle_ns is uint64_t, cannot be negative */
+    if (status->duty_cycle_percent < 0.0f)   status->duty_cycle_percent = 0.0f;
 
     return PWM_SUCCESS;
 }

--- a/framework-lgpio/pwm-hal.h
+++ b/framework-lgpio/pwm-hal.h
@@ -24,8 +24,8 @@
  *
  * @file pwm-hal.h
  * @author PlatformIO Linux ARM Platform
- * @version 1.0.0
- * @date 2025-11-12
+ * @version 2.0.0
+ * @date 2026-04-16
  */
 
 #ifndef PWM_HAL_H
@@ -76,6 +76,9 @@ typedef struct {
     uint64_t period_ns;        /**< Period in nanoseconds */
     uint64_t duty_cycle_ns;    /**< Duty cycle in nanoseconds */
 } pwm_status_t;
+
+/** @brief Alias for pwm_status_t — preferred name for use with pwm_get_state() */
+typedef pwm_status_t pwm_state_t;
 
 /**
  * @brief Hardware limits for PWM operation
@@ -185,7 +188,7 @@ int pwm_set_frequency(int pin, uint32_t freq_hz);
 int pwm_set_polarity(int pin, pwm_polarity_t polarity);
 
 /**
- * @brief Query current PWM status and configuration
+ * @brief Query current PWM configuration (write-shadow cache)
  *
  * Retrieves detailed information about the PWM channel including frequency,
  * duty cycle, polarity, and enable state. Useful for debugging and monitoring.
@@ -196,10 +199,37 @@ int pwm_set_polarity(int pin, pwm_polarity_t polarity);
  *
  * @note status parameter must not be NULL
  * @note Returns cached (write-shadow) state — values reflect the last written
- *       configuration, not live hardware registers. Live readback is tracked
- *       in issue #124.
+ *       configuration, not live hardware registers. Use pwm_sample_hardware()
+ *       to read live sysfs state directly.
  */
-int pwm_get_status(int pin, pwm_status_t *status);
+int pwm_get_state(int pin, pwm_state_t *status);
+
+/**
+ * @brief Read live hardware state directly from sysfs
+ *
+ * Reads the current PWM hardware registers via sysfs, bypassing the
+ * write-shadow cache. Use when you need to verify actual hardware state,
+ * e.g., after a suspected hardware reset or for diagnostic tooling.
+ *
+ * More expensive than pwm_get_state() — performs 4 sysfs reads (period,
+ * duty_cycle, enable, polarity).
+ *
+ * @param pin GPIO pin number (BCM numbering)
+ * @param status Pointer to pwm_status_t structure to fill
+ * @return PWM_SUCCESS on success, error code on failure
+ *
+ * @note pin must be initialized with pwm_init() first
+ * @note status parameter must not be NULL
+ * @note The 4 sysfs reads are not atomic.  If another process modifies PWM
+ *       hardware state between reads, the returned struct may represent an
+ *       inconsistent snapshot (e.g., period from before a frequency change,
+ *       duty_cycle from after).  Suitable for diagnostics; do not use for
+ *       real-time synchronisation.
+ * @note status->frequency_hz is derived via integer division (1 GHz /
+ *       period_ns) and may differ slightly from the value originally passed
+ *       to pwm_init() or pwm_set_frequency() due to rounding.
+ */
+int pwm_sample_hardware(int pin, pwm_state_t *status);
 
 /**
  * @brief Check if PWM channel is enabled

--- a/platform.json
+++ b/platform.json
@@ -16,7 +16,7 @@
     "type": "git",
     "url": "https://github.com/sfo2001/platform-linux_arm.git"
   },
-  "version": "1.9.0",
+  "version": "2.0.0",
   "frameworks": {
     "libgpiod": {
       "script": "builder/frameworks/libgpiod.py",

--- a/tests/stubs/pwm-hal-sysfs-stub.c
+++ b/tests/stubs/pwm-hal-sysfs-stub.c
@@ -12,11 +12,13 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdbool.h>
+#include <assert.h>
 
 /* Tracks which chip+channel pairs have been exported. */
 /* Chips 0..7, channels 0..1 — matches MAX_PWM_CHANNELS and HAL limits. */
 #define STUB_MAX_CHIPS    8
 #define STUB_MAX_CHANNELS 2
+#define STUB_MAX_READ_OVERRIDES 8
 
 static bool s_use_pi5;
 static bool s_exported[STUB_MAX_CHIPS][STUB_MAX_CHANNELS];
@@ -27,6 +29,21 @@ static int         s_write_fail_error;
 static const char *s_write_fail_after_suffix;
 static int         s_write_fail_after_error;
 static int         s_write_fail_after_count;
+
+/* Per-path read value overrides */
+typedef struct {
+    const char *suffix;
+    const char *value;
+} stub_read_value_t;
+
+/* Per-path one-shot read failure injection */
+typedef struct {
+    const char *suffix;
+    int         error_code;
+} stub_read_fail_t;
+
+static stub_read_value_t s_read_values[STUB_MAX_READ_OVERRIDES];
+static stub_read_fail_t  s_read_fails[STUB_MAX_READ_OVERRIDES];
 
 /* ---- Stub control ---- */
 
@@ -43,6 +60,12 @@ void stub_reset(void) {
         for (int ch = 0; ch < STUB_MAX_CHANNELS; ch++) {
             s_exported[c][ch] = false;
         }
+    }
+    for (int i = 0; i < STUB_MAX_READ_OVERRIDES; i++) {
+        s_read_values[i].suffix = NULL;
+        s_read_values[i].value  = NULL;
+        s_read_fails[i].suffix     = NULL;
+        s_read_fails[i].error_code = 0;
     }
 }
 
@@ -64,6 +87,41 @@ void stub_set_write_fail_after(const char *path_suffix, int error_code,
     s_write_fail_after_suffix = path_suffix;
     s_write_fail_after_error  = error_code;
     s_write_fail_after_count  = n_successes_before_fail;
+}
+
+void stub_set_read_value(const char *path_suffix, const char *value) {
+    for (int i = 0; i < STUB_MAX_READ_OVERRIDES; i++) {
+        /* Update existing entry for this suffix if present */
+        if (s_read_values[i].suffix != NULL &&
+            strcmp(s_read_values[i].suffix, path_suffix) == 0) {
+            s_read_values[i].value = value;
+            return;
+        }
+    }
+    /* Otherwise find a free slot */
+    for (int i = 0; i < STUB_MAX_READ_OVERRIDES; i++) {
+        if (s_read_values[i].suffix == NULL) {
+            s_read_values[i].suffix = path_suffix;
+            s_read_values[i].value  = value;
+            return;
+        }
+    }
+    /* No free slot found — table is full */
+    fprintf(stderr, "stub_set_read_value: overflow — increase STUB_MAX_READ_OVERRIDES\n");
+    assert(0 && "stub_set_read_value: table full");
+}
+
+void stub_set_read_fail_on(const char *path_suffix, int error_code) {
+    for (int i = 0; i < STUB_MAX_READ_OVERRIDES; i++) {
+        if (s_read_fails[i].suffix == NULL) {
+            s_read_fails[i].suffix     = path_suffix;
+            s_read_fails[i].error_code = error_code;
+            return;
+        }
+    }
+    /* No free slot found — table is full */
+    fprintf(stderr, "stub_set_read_fail_on: overflow — increase STUB_MAX_READ_OVERRIDES\n");
+    assert(0 && "stub_set_read_fail_on: table full");
 }
 
 /* ---- Seam function implementations ---- */
@@ -153,9 +211,33 @@ int pwm_sysfs_write(const char *path, const char *value) {
 }
 
 int pwm_sysfs_read(const char *path, char *value, size_t max_len) {
-    (void)path;
-    /* Return a safe default — tests that need specific read values should
-     * extend the stub with a per-path override table. */
+    size_t plen = strlen(path);
+
+    /* Check one-shot read failure table first */
+    for (int i = 0; i < STUB_MAX_READ_OVERRIDES; i++) {
+        if (s_read_fails[i].suffix == NULL) continue;
+        size_t slen = strlen(s_read_fails[i].suffix);
+        if (plen >= slen &&
+            strcmp(path + plen - slen, s_read_fails[i].suffix) == 0) {
+            int err = s_read_fails[i].error_code;
+            s_read_fails[i].suffix = NULL; /* consume — one-shot */
+            return err;
+        }
+    }
+
+    /* Check per-path value override table */
+    for (int i = 0; i < STUB_MAX_READ_OVERRIDES; i++) {
+        if (s_read_values[i].suffix == NULL) continue;
+        size_t slen = strlen(s_read_values[i].suffix);
+        if (plen >= slen &&
+            strcmp(path + plen - slen, s_read_values[i].suffix) == 0) {
+            if (max_len > 0) {
+                snprintf(value, max_len, "%s", s_read_values[i].value);
+            }
+            return PWM_SUCCESS;
+        }
+    }
+
     if (max_len > 0) {
         strncpy(value, "0", max_len);
         value[max_len - 1] = '\0';

--- a/tests/stubs/pwm-hal-sysfs-stub.h
+++ b/tests/stubs/pwm-hal-sysfs-stub.h
@@ -57,4 +57,26 @@ void stub_set_write_fail_on(const char *path_suffix, int error_code);
 void stub_set_write_fail_after(const char *path_suffix, int error_code,
                                int n_successes_before_fail);
 
+/**
+ * Override the value returned by pwm_sysfs_read() for paths ending with
+ * path_suffix.  The override persists until stub_reset() is called.
+ *
+ * Use to simulate specific sysfs attribute values for pwm_sample_hardware().
+ * Example: stub_set_read_value("/period", "1000000") → 1 kHz period.
+ *
+ * @param path_suffix  Suffix to match (e.g. "/period", "/polarity")
+ * @param value        Value string to return (NUL-terminated)
+ */
+void stub_set_read_value(const char *path_suffix, const char *value);
+
+/**
+ * Inject a one-shot read failure for paths ending with path_suffix.
+ * The next matching pwm_sysfs_read() call returns error_code and the
+ * trigger is consumed.
+ *
+ * @param path_suffix  Suffix to match (e.g. "/period")
+ * @param error_code   Error to return (e.g. PWM_ERROR_IO)
+ */
+void stub_set_read_fail_on(const char *path_suffix, int error_code);
+
 #endif /* PWM_HAL_SYSFS_STUB_H */

--- a/tests/test_pwm_hal.c
+++ b/tests/test_pwm_hal.c
@@ -208,7 +208,7 @@ static void test_set_frequency_valid(void) {
     int result = pwm_set_frequency(18, 2000);
     assert(result == PWM_SUCCESS);
     pwm_status_t status;
-    assert(pwm_get_status(18, &status) == PWM_SUCCESS);
+    assert(pwm_get_state(18, &status) == PWM_SUCCESS);
     assert(status.frequency_hz == 2000);
 }
 
@@ -236,20 +236,20 @@ static void test_set_polarity_inverted(void) {
     int result = pwm_set_polarity(18, PWM_POLARITY_INVERTED);
     assert(result == PWM_SUCCESS);
     pwm_status_t status;
-    assert(pwm_get_status(18, &status) == PWM_SUCCESS);
+    assert(pwm_get_state(18, &status) == PWM_SUCCESS);
     assert(status.polarity == PWM_POLARITY_INVERTED);
 }
 
 /**
- * T17: pwm_get_status(18, &status) after init reflects the expected state.
+ * T17: pwm_get_state(18, &status) after init reflects the expected state.
  */
-static void test_get_status_after_init(void) {
+static void test_get_state_after_init(void) {
     stub_reset();
     pwm_reset_state_for_testing();
 
     assert(pwm_init(18, 1000) == PWM_SUCCESS);
     pwm_status_t status;
-    int result = pwm_get_status(18, &status);
+    int result = pwm_get_state(18, &status);
     assert(result == PWM_SUCCESS);
     assert(status.gpio_pin == 18);
     assert(status.pwm_chip == 0);
@@ -259,6 +259,8 @@ static void test_get_status_after_init(void) {
     assert(status.frequency_hz == 1000);
     assert(status.duty_cycle_percent == 0.0f);
     assert(status.polarity == PWM_POLARITY_NORMAL);
+    assert(status.period_ns == 1000000ULL);
+    assert(status.duty_cycle_ns == 0ULL);
 }
 
 /**
@@ -364,15 +366,15 @@ static void test_deinit_before_init_succeeds(void) {
 }
 
 /**
- * T26: pwm_get_status(18, NULL) returns PWM_ERROR_INVALID_PARAM.
+ * T26: pwm_get_state(18, NULL) returns PWM_ERROR_INVALID_PARAM.
  * NULL status pointer is rejected before state lookup.
  */
-static void test_get_status_null_ptr_fails(void) {
+static void test_get_state_null_ptr_fails(void) {
     stub_reset();
     pwm_reset_state_for_testing();
 
     assert(pwm_init(18, 1000) == PWM_SUCCESS);
-    int result = pwm_get_status(18, NULL);
+    int result = pwm_get_state(18, NULL);
     assert(result == PWM_ERROR_INVALID_PARAM);
 }
 
@@ -577,15 +579,15 @@ static void test_init_freq_too_high(void) {
 }
 
 /**
- * T40: pwm_get_status(18, &status) before any init returns PWM_ERROR_NOT_EXPORTED.
+ * T40: pwm_get_state(18, &status) before any init returns PWM_ERROR_NOT_EXPORTED.
  * pwm_find_state() returns NULL → NOT_EXPORTED.
  */
-static void test_get_status_before_init_fails(void) {
+static void test_get_state_before_init_fails(void) {
     stub_reset();
     pwm_reset_state_for_testing();
 
     pwm_status_t status;
-    int result = pwm_get_status(18, &status);
+    int result = pwm_get_state(18, &status);
     assert(result == PWM_ERROR_NOT_EXPORTED);
 }
 
@@ -632,7 +634,7 @@ static void test_init_max_freq_succeeds(void) {
     assert(result == PWM_SUCCESS);
 
     pwm_status_t status;
-    assert(pwm_get_status(18, &status) == PWM_SUCCESS);
+    assert(pwm_get_state(18, &status) == PWM_SUCCESS);
     assert(status.period_ns == 10);
     assert(status.frequency_hz == PWM_MAX_FREQUENCY_HZ);
 }
@@ -766,6 +768,227 @@ static void test_init_fails_when_all_slots_full(void) {
 }
 
 /* ============================================================
+ * T51-T55: pwm_sample_hardware tests
+ * ============================================================ */
+
+/**
+ * T51: pwm_sample_hardware(18, &status) after init with stub values set
+ * returns PWM_SUCCESS and correctly parsed hardware fields.
+ * - period = 1000000 ns → 1 kHz
+ * - duty_cycle = 500000 ns → 50%
+ * - enable = 1 → is_enabled = true
+ * - polarity = "normal" → PWM_POLARITY_NORMAL
+ */
+static void test_sample_hardware_after_init(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+
+    stub_set_read_value("/period",     "1000000");
+    stub_set_read_value("/duty_cycle", "500000");
+    stub_set_read_value("/enable",     "1");
+    stub_set_read_value("/polarity",   "normal");
+
+    pwm_status_t status;
+    int result = pwm_sample_hardware(18, &status);
+    assert(result == PWM_SUCCESS);
+    assert(status.frequency_hz == 1000);
+    assert(status.duty_cycle_percent == 50.0f);
+    assert(status.is_enabled == true);
+    assert(status.polarity == PWM_POLARITY_NORMAL);
+    assert(status.period_ns == 1000000ULL);
+    assert(status.duty_cycle_ns == 500000ULL);
+    assert(status.gpio_pin == 18);
+    assert(status.pwm_chip == 0);
+    assert(status.pwm_channel == 0);
+    assert(status.is_exported == true);
+}
+
+/**
+ * T52: pwm_sample_hardware(18, NULL) returns PWM_ERROR_INVALID_PARAM.
+ * NULL status pointer is rejected before state lookup.
+ */
+static void test_sample_hardware_null_ptr_fails(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    int result = pwm_sample_hardware(18, NULL);
+    assert(result == PWM_ERROR_INVALID_PARAM);
+}
+
+/**
+ * T53: pwm_sample_hardware(18, &status) before any init returns
+ * PWM_ERROR_NOT_EXPORTED.  pwm_find_state() returns NULL.
+ */
+static void test_sample_hardware_before_init_fails(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    pwm_status_t status;
+    int result = pwm_sample_hardware(18, &status);
+    assert(result == PWM_ERROR_NOT_EXPORTED);
+}
+
+/**
+ * T54: pwm_sample_hardware(18, &status) returns PWM_ERROR_IO when the
+ * period sysfs read fails.  Uses one-shot read failure injection on "/period".
+ */
+static void test_sample_hardware_period_read_fails(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    stub_set_read_fail_on("/period", PWM_ERROR_IO);
+
+    pwm_status_t status;
+    int result = pwm_sample_hardware(18, &status);
+    assert(result == PWM_ERROR_IO);
+}
+
+/**
+ * T55: pwm_sample_hardware(18, &status) returns PWM_ERROR_IO when period_ns
+ * is zero.  A zero period is invalid (would cause division by zero in
+ * frequency_hz computation).
+ */
+static void test_sample_hardware_zero_period_fails(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    stub_set_read_value("/period", "0");
+
+    pwm_status_t status;
+    int result = pwm_sample_hardware(18, &status);
+    assert(result == PWM_ERROR_IO);
+}
+
+/* ============================================================
+ * T56-T59: pwm_sample_hardware read-failure and inverted polarity tests
+ * ============================================================ */
+
+/**
+ * T56: pwm_sample_hardware(18, &status) returns PWM_ERROR_IO when the
+ * duty_cycle sysfs read fails.  Period succeeds; duty_cycle is the second
+ * read in pwm_sample_hardware so the one-shot fires there.
+ */
+static void test_sample_hardware_duty_read_fails(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    stub_set_read_value("/period",     "1000000");
+    stub_set_read_fail_on("/duty_cycle", PWM_ERROR_IO);
+
+    pwm_status_t status;
+    int result = pwm_sample_hardware(18, &status);
+    assert(result == PWM_ERROR_IO);
+}
+
+/**
+ * T57: pwm_sample_hardware(18, &status) returns PWM_ERROR_IO when the
+ * enable sysfs read fails.  Period and duty_cycle succeed; enable is the
+ * third read so the one-shot fires there.
+ */
+static void test_sample_hardware_enable_read_fails(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    stub_set_read_value("/period",     "1000000");
+    stub_set_read_value("/duty_cycle", "500000");
+    stub_set_read_fail_on("/enable", PWM_ERROR_IO);
+
+    pwm_status_t status;
+    int result = pwm_sample_hardware(18, &status);
+    assert(result == PWM_ERROR_IO);
+}
+
+/**
+ * T58: pwm_sample_hardware(18, &status) returns PWM_ERROR_IO when the
+ * polarity sysfs read fails.  The three preceding reads succeed; polarity
+ * is the fourth read so the one-shot fires there.
+ */
+static void test_sample_hardware_polarity_read_fails(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    stub_set_read_value("/period",     "1000000");
+    stub_set_read_value("/duty_cycle", "500000");
+    stub_set_read_value("/enable",     "1");
+    stub_set_read_fail_on("/polarity", PWM_ERROR_IO);
+
+    pwm_status_t status;
+    int result = pwm_sample_hardware(18, &status);
+    assert(result == PWM_ERROR_IO);
+}
+
+/**
+ * T59: pwm_sample_hardware(18, &status) returns PWM_SUCCESS and sets
+ * status.polarity == PWM_POLARITY_INVERTED when the polarity sysfs file
+ * contains "inversed" (the kernel spelling per Documentation/driver-api/pwm.rst).
+ */
+static void test_sample_hardware_inverted_polarity(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    stub_set_read_value("/period",     "1000000");
+    stub_set_read_value("/duty_cycle", "500000");
+    stub_set_read_value("/enable",     "1");
+    stub_set_read_value("/polarity",   "inversed");
+
+    pwm_status_t status;
+    int result = pwm_sample_hardware(18, &status);
+    assert(result == PWM_SUCCESS);
+    assert(status.polarity == PWM_POLARITY_INVERTED);
+}
+
+/**
+ * T60: pwm_sample_hardware(18, &status) returns PWM_SUCCESS and
+ * duty_cycle_percent == 100.0f when duty_cycle_ns > period_ns (sysfs race).
+ * The raw duty_cycle_ns in the returned struct must also be clamped to period_ns.
+ */
+static void test_sample_hardware_duty_exceeds_period(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    stub_set_read_value("/period",     "1000");
+    stub_set_read_value("/duty_cycle", "2000");
+    stub_set_read_value("/enable",     "1");
+    stub_set_read_value("/polarity",   "normal");
+
+    pwm_status_t status;
+    int result = pwm_sample_hardware(18, &status);
+    assert(result == PWM_SUCCESS);
+    assert(status.duty_cycle_percent == 100.0f);
+    assert(status.duty_cycle_ns == 1000ULL); /* clamped to period_ns */
+}
+
+/**
+ * T61: pwm_sample_hardware(18, &status) returns PWM_ERROR_IO when the
+ * polarity sysfs file contains an unrecognised string (not "normal" or
+ * "inversed").
+ */
+static void test_sample_hardware_unknown_polarity(void) {
+    stub_reset();
+    pwm_reset_state_for_testing();
+
+    assert(pwm_init(18, 1000) == PWM_SUCCESS);
+    stub_set_read_value("/period",     "1000000");
+    stub_set_read_value("/duty_cycle", "500000");
+    stub_set_read_value("/enable",     "1");
+    stub_set_read_value("/polarity",   "bogus");
+
+    pwm_status_t status;
+    int result = pwm_sample_hardware(18, &status);
+    assert(result == PWM_ERROR_IO);
+}
+
+/* ============================================================
  * Main
  * ============================================================ */
 
@@ -786,7 +1009,7 @@ int main(void) {
     RUN(test_set_frequency_valid);
     RUN(test_set_polarity_normal);
     RUN(test_set_polarity_inverted);
-    RUN(test_get_status_after_init);
+    RUN(test_get_state_after_init);
     RUN(test_is_enabled_after_init);
     RUN(test_is_enabled_before_init);
     RUN(test_export_timeout);
@@ -795,7 +1018,7 @@ int main(void) {
     RUN(test_set_polarity_before_init_fails);
     RUN(test_set_polarity_invalid_value);
     RUN(test_deinit_before_init_succeeds);
-    RUN(test_get_status_null_ptr_fails);
+    RUN(test_get_state_null_ptr_fails);
     RUN(test_get_chip_channel_null_fails);
     RUN(test_write_boundary_zero);
     RUN(test_write_boundary_full);
@@ -809,7 +1032,7 @@ int main(void) {
     RUN(test_pin_is_valid_all_pi14_pins);
     RUN(test_pin_is_valid_pi5_pins);
     RUN(test_init_freq_too_high);
-    RUN(test_get_status_before_init_fails);
+    RUN(test_get_state_before_init_fails);
     RUN(test_write_fails_on_sysfs_io);
     RUN(test_set_frequency_fails_on_duty_write);
     RUN(test_init_max_freq_succeeds);
@@ -820,6 +1043,17 @@ int main(void) {
     RUN(test_deinit_unexport_fail_propagates);
     RUN(test_init_fails_on_export_write);
     RUN(test_init_fails_when_all_slots_full);
+    RUN(test_sample_hardware_after_init);
+    RUN(test_sample_hardware_null_ptr_fails);
+    RUN(test_sample_hardware_before_init_fails);
+    RUN(test_sample_hardware_period_read_fails);
+    RUN(test_sample_hardware_zero_period_fails);
+    RUN(test_sample_hardware_duty_read_fails);
+    RUN(test_sample_hardware_enable_read_fails);
+    RUN(test_sample_hardware_polarity_read_fails);
+    RUN(test_sample_hardware_inverted_polarity);
+    RUN(test_sample_hardware_duty_exceeds_period);
+    RUN(test_sample_hardware_unknown_polarity);
 
     printf("\nAll %d tests passed.\n", g_tests_run);
     return 0;


### PR DESCRIPTION
## Description

Closes #124.

Adds `pwm_sample_hardware()` for live sysfs readback (bypasses write-shadow cache — reads actual hardware registers for period, duty_cycle, enable, polarity). Useful for diagnostics or verifying hardware state after a suspected reset. The 4 sysfs reads are not atomic.

**Breaking change:** `pwm_get_status()` renamed to `pwm_get_state()` to match kernel/libgpiod naming convention (`state` = last-configured). `pwm_status_t` struct and members unchanged; `pwm_state_t` typedef added as preferred alias. Source-level rename and recompile required — downstream binaries linked against the old symbol will not link.

Bumps version to **2.0.0** to reflect semver MAJOR change.

**AI assistance:** Implementation and tests developed with Claude Sonnet 4.6. All generated code reviewed and understood. Fully tested via CMake/ctest (61 unit tests, no hardware required). Build-only on target hardware — no Raspberry Pi runtime test.

---

## Type of Change

- [x] [BREAKING] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] [FEATURE] New feature (non-breaking change which adds functionality)
- [x] [TEST] Test update

---

## Related Issues

Closes #124

---

## Checklist

### Testing

- [x] I have tested my changes locally
- [x] I have built all examples successfully
- [ ] I have tested on target hardware (if applicable) — build-only; no Pi hardware available
- [x] All CI/CD checks pass
- [x] I have tested both 32-bit and 64-bit builds (if applicable)

### Code Quality

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly
- [x] I have updated CONTRIBUTING.md if needed
- [x] I have updated the README.md if needed
- [ ] I have added or updated board definitions if needed — N/A
- [x] My commit messages follow the Conventional Commits specification

### Framework Changes (if applicable)

- [x] I have tested the framework with examples
- [x] I have verified cross-compilation works
- [x] I have updated framework documentation
- [ ] I have tested on multiple Pi models (if applicable) — build-only

### AI-Assisted Contributions (if applicable)

- [x] I have disclosed the AI tool(s) used and the scope of assistance in the description above
- [x] I have reviewed and understand all AI-generated code in this PR
- [x] I have noted the degree of testing (untested / lightly tested / fully tested)
- [x] AI `Co-Authored-By:` commit trailers have been removed before submitting
- [x] If hardware was involved, I have noted whether it was tested on real hardware or build-only

---

## Test Results

### Build Test Results

```
cmake -B build -DUNIT_TESTING=1 && cmake --build build && ctest --test-dir build
-- 61 tests registered
-- 61/61 tests passed
```

### Breaking Change Migration

Replace every call site:
```c
// Before
pwm_status_t s;
pwm_get_status(pin, &s);

// After
pwm_state_t s;   // or pwm_status_t — both valid, pwm_state_t preferred
pwm_get_state(pin, &s);
```

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**