### PR TITLE
chore(release): 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-04-16
+
 ### Breaking Changes
 
 - **BREAKING** `pwm_get_status()` renamed to `pwm_get_state()` — formalises write-shadow as
@@ -20,8 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   This is a **semver MAJOR** bump — downstream binaries linked against the old symbol will
   not link; a source-level rename and recompile is required.
-
-### Changed
 
 ### Added
 - `pwm_sample_hardware()` — reads live hardware registers via sysfs (4 reads: period,


### PR DESCRIPTION
## Description

Finalises the `[Unreleased]` section of CHANGELOG.md as `[2.0.0] - 2026-04-16`.
Removes the empty `### Changed` stub. Adds a fresh empty `## [Unreleased]` header for future work.

No code changes — CHANGELOG only.

## Type of Change

- [x] [DOCS] Documentation update

## Related Issues

Closes the release of changes introduced in #126 (#124).

## Checklist

### Testing
- [x] All CI/CD checks pass

### Documentation
- [x] CHANGELOG updated to `[2.0.0] - 2026-04-16`
- [x] My commit messages follow the Conventional Commits specification

---

**After merge:** tag `v2.0.0` on the resulting develop commit.

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**